### PR TITLE
feat: #27 realtime notifications (WebSocket + REST + community wiring)

### DIFF
--- a/backend/alembic/versions/0006_notifications.py
+++ b/backend/alembic/versions/0006_notifications.py
@@ -1,0 +1,70 @@
+"""notifications table.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-18
+
+Avoids the 0005 duplicate-enum pitfall: we let `sa.Enum` inside
+`create_table` own the enum-type lifecycle (no pre-create step).
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id", sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "type",
+            sa.Enum(
+                "comment", "like", "mention", "knowledge_update",
+                name="notification_type",
+            ),
+            nullable=False,
+        ),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="{}"),
+        sa.Column("title", sa.String(500), nullable=True),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True),
+            server_default=sa.func.now(), nullable=False,
+        ),
+    )
+    op.create_index("ix_notifications_id",         "notifications", ["id"])
+    op.create_index("ix_notifications_user_id",    "notifications", ["user_id"])
+    op.create_index("ix_notifications_type",       "notifications", ["type"])
+    op.create_index("ix_notifications_read_at",    "notifications", ["read_at"])
+    op.create_index("ix_notifications_created_at", "notifications", ["created_at"])
+    # Common query is "unread for this user ordered by newest" — cover it.
+    op.create_index(
+        "ix_notifications_user_unread",
+        "notifications",
+        ["user_id", "created_at"],
+        postgresql_where=sa.text("read_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_user_unread", table_name="notifications")
+    op.drop_index("ix_notifications_created_at",  table_name="notifications")
+    op.drop_index("ix_notifications_read_at",     table_name="notifications")
+    op.drop_index("ix_notifications_type",        table_name="notifications")
+    op.drop_index("ix_notifications_user_id",     table_name="notifications")
+    op.drop_index("ix_notifications_id",          table_name="notifications")
+    op.drop_table("notifications")
+    sa.Enum(name="notification_type").drop(op.get_bind(), checkfirst=True)

--- a/backend/app/core/ws.py
+++ b/backend/app/core/ws.py
@@ -1,0 +1,75 @@
+"""Per-user WebSocket connection registry.
+
+A single process holds a mapping `user_id → set[WebSocket]`. Publishing
+to a user fans out to every live socket that user has open (multiple
+tabs, desktop + phone, etc.).
+
+Multi-process note: in a single-replica dev deployment this is fine.
+When we scale to >1 backend replica, swap the in-memory `_peers` for a
+Redis pub/sub bridge — the public interface (`connect`/`disconnect`/
+`send_to_user`) stays the same. Until then, keep it simple.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from typing import Any
+
+from fastapi import WebSocket
+
+log = logging.getLogger(__name__)
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self._peers: dict[int, set[WebSocket]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+
+    async def connect(self, user_id: int, ws: WebSocket) -> None:
+        """Register an already-accepted WebSocket for `user_id`.
+
+        Caller is responsible for ws.accept() (so auth can deny BEFORE
+        registering).
+        """
+        async with self._lock:
+            self._peers[user_id].add(ws)
+
+    async def disconnect(self, user_id: int, ws: WebSocket) -> None:
+        async with self._lock:
+            peers = self._peers.get(user_id)
+            if peers is None:
+                return
+            peers.discard(ws)
+            if not peers:
+                self._peers.pop(user_id, None)
+
+    async def send_to_user(self, user_id: int, payload: dict[str, Any]) -> int:
+        """Fan out `payload` to every live socket for `user_id`.
+
+        Returns the count of sockets successfully written to. Dead sockets
+        are dropped silently — they'll clean themselves up next heartbeat.
+        """
+        peers = list(self._peers.get(user_id, ()))
+        if not peers:
+            return 0
+
+        text = json.dumps(payload, ensure_ascii=False, default=str)
+        ok = 0
+        for ws in peers:
+            try:
+                await ws.send_text(text)
+                ok += 1
+            except Exception as exc:  # noqa: BLE001
+                log.info("WS send failed for user=%s: %s — dropping", user_id, exc)
+                # Best-effort cleanup; the endpoint's finally-block also unregisters.
+                await self.disconnect(user_id, ws)
+        return ok
+
+    def online_count(self) -> int:
+        return len(self._peers)
+
+
+# Module-level singleton. Process-local — see docstring for scaling note.
+manager = ConnectionManager()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app.routers import community
 from app.routers import ai
 from app.routers import feedback
 from app.routers import graph as graph_router
+from app.routers import notifications
 
 
 @asynccontextmanager
@@ -92,6 +93,7 @@ app.include_router(ai.router)
 for _r in feedback.routers:
     app.include_router(_r)
 app.include_router(graph_router.router)
+app.include_router(notifications.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.document import DocumentChunk, DocumentParseRecord, ParseStatus
 from app.models.version import KnowledgeVersion
 from app.models.community import Post, Reply, ReplyLike
 from app.models.feedback import ChatFeedback, FeedbackRating
+from app.models.notification import Notification, NotificationType
 
 __all__ = [
     "User", "UserRole",
@@ -16,4 +17,5 @@ __all__ = [
     "KnowledgeVersion",
     "Post", "Reply", "ReplyLike",
     "ChatFeedback", "FeedbackRating",
+    "Notification", "NotificationType",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,66 @@
+"""Community / knowledge notifications.
+
+One row per notification event, owned by `user_id` (the recipient).
+`read_at` NULL = unread; flipped to `now()` when the user acks it.
+
+`payload` is JSONB — each event type writes a different shape, but all
+include enough to render the item on the frontend without a join:
+
+  comment : { post_id, reply_id, actor_id, actor_name, snippet }
+  like    : { reply_id, actor_id, actor_name }
+  mention : { post_id, reply_id, actor_id, actor_name, snippet }
+  knowledge_update : { knowledge_id, name, change_summary }
+
+Offline delivery is just "rows with read_at IS NULL created before the
+current WS connection time" — no separate queue table needed. When the
+socket opens we flush the unread backlog and keep streaming live events.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class NotificationType(str, enum.Enum):
+    COMMENT          = "comment"           # new reply on your post
+    LIKE             = "like"              # someone liked your reply
+    MENTION          = "mention"           # @user in a reply
+    KNOWLEDGE_UPDATE = "knowledge_update"  # doc you care about changed
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    type: Mapped[NotificationType] = mapped_column(
+        Enum(NotificationType, name="notification_type"),
+        nullable=False, index=True,
+    )
+    # Free-form per-type payload; see module docstring for the shape.
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    # Optional short human-readable title — makes the list endpoint cheap
+    # (no need to format from payload server-side).
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    read_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+        nullable=False, index=True,
+    )
+
+    user: Mapped["User"] = relationship("User")  # noqa: F821
+
+    def __repr__(self) -> str:
+        return f"<Notification id={self.id} type={self.type.value} user={self.user_id}>"

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -43,7 +43,15 @@ class Notification(Base):
         nullable=False, index=True,
     )
     type: Mapped[NotificationType] = mapped_column(
-        Enum(NotificationType, name="notification_type"),
+        # `values_callable` makes SQLAlchemy persist the enum *value*
+        # ("comment") instead of its name ("COMMENT"), matching the
+        # lowercase labels in the Postgres enum. Same fix we applied to
+        # UserRole last cycle — see that commit for the long story.
+        Enum(
+            NotificationType,
+            values_callable=lambda obj: [e.value for e in obj],
+            name="notification_type",
+        ),
         nullable=False, index=True,
     )
     # Free-form per-type payload; see module docstring for the shape.
@@ -64,3 +72,19 @@ class Notification(Base):
 
     def __repr__(self) -> str:
         return f"<Notification id={self.id} type={self.type.value} user={self.user_id}>"
+
+    def to_dict(self) -> dict:
+        """Canonical wire-format for a Notification.
+
+        Used by both the REST serializer and the WS push payload so they
+        never drift. Keep this file authoritative — if you need a new
+        field on the client, add it here.
+        """
+        return {
+            "id": self.id,
+            "type": self.type.value,
+            "title": self.title,
+            "payload": self.payload,
+            "read": self.read_at is not None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/backend/app/routers/community.py
+++ b/backend/app/routers/community.py
@@ -16,6 +16,7 @@ Endpoints:
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Query
@@ -25,7 +26,30 @@ from sqlalchemy.exc import IntegrityError
 
 from app.core.deps import CurrentUser, DB
 from app.models.community import Post, Reply, ReplyLike
-from app.models.user import UserRole
+from app.models.notification import NotificationType
+from app.models.user import User, UserRole
+from app.services.notify import dispatch as notify_dispatch
+
+
+# @username mentions — allow word chars including CJK. Stop at whitespace
+# or common punctuation. Deliberately permissive; the DB lookup is the
+# real filter.
+_MENTION_RE = re.compile(r"@([\w\u4e00-\u9fff]+)")
+
+
+async def _resolve_mentions(db, content: str, exclude_user_id: int) -> list[User]:
+    names = set(_MENTION_RE.findall(content or ""))
+    if not names:
+        return []
+    rows = (await db.execute(
+        select(User).where(User.username.in_(names), User.id != exclude_user_id)
+    )).scalars().all()
+    return list(rows)
+
+
+def _content_snippet(s: str, n: int = 120) -> str:
+    s = (s or "").strip().replace("\n", " ")
+    return s if len(s) <= n else s[: n - 1] + "…"
 
 
 # Separate routers so we can mount /posts and /replies with cleanly
@@ -178,10 +202,76 @@ async def create_reply(
         content=payload.content,
     )
     db.add(r)
+    await db.flush()  # need r.id for the notification payload
 
     # Bump post.reply_count so the feed view doesn't need a JOIN+COUNT.
     post = await _load_post(db, post_id)
     post.reply_count = (post.reply_count or 0) + 1
+
+    # ─── Notifications ──────────────────────────────────────────────────
+    # Dispatch three fan-out cases. All go through notify.dispatch which
+    # inserts a Notification row (commits with this transaction) and best-
+    # effort pushes over WS. We dedupe recipients so the same user never
+    # gets two notifications from one reply.
+    snippet = _content_snippet(payload.content)
+    notified: set[int] = {user.id}  # never notify yourself
+
+    # 1. Post author — "new comment on your post" (only for top-level replies
+    #    to keep signal-to-noise reasonable; nested comments notify the
+    #    parent-reply author instead, below).
+    if parent is None and post.author_id not in notified:
+        await notify_dispatch(
+            db,
+            user_id=post.author_id,
+            type=NotificationType.COMMENT,
+            title=f"{user.username} 评论了你的帖子",
+            payload={
+                "post_id": post_id,
+                "reply_id": r.id,
+                "actor_id": user.id,
+                "actor_name": user.username,
+                "snippet": snippet,
+            },
+        )
+        notified.add(post.author_id)
+
+    # 2. Parent-reply author — "someone replied to your comment".
+    if parent is not None and parent.author_id not in notified:
+        await notify_dispatch(
+            db,
+            user_id=parent.author_id,
+            type=NotificationType.COMMENT,
+            title=f"{user.username} 回复了你的评论",
+            payload={
+                "post_id": post_id,
+                "reply_id": r.id,
+                "parent_reply_id": parent.id,
+                "actor_id": user.id,
+                "actor_name": user.username,
+                "snippet": snippet,
+            },
+        )
+        notified.add(parent.author_id)
+
+    # 3. @mentions — parse out @usernames and ping each distinct user.
+    for mentioned in await _resolve_mentions(db, payload.content, user.id):
+        if mentioned.id in notified:
+            continue
+        await notify_dispatch(
+            db,
+            user_id=mentioned.id,
+            type=NotificationType.MENTION,
+            title=f"{user.username} 在评论中提到了你",
+            payload={
+                "post_id": post_id,
+                "reply_id": r.id,
+                "actor_id": user.id,
+                "actor_name": user.username,
+                "snippet": snippet,
+            },
+        )
+        notified.add(mentioned.id)
+
     await db.commit()
     await db.refresh(r)
     return _reply_dict(r)
@@ -223,6 +313,22 @@ async def like_reply(reply_id: int, db: DB, user: CurrentUser):
 
     db.add(ReplyLike(reply_id=reply_id, user_id=user.id))
     r.like_count = (r.like_count or 0) + 1
+
+    # Notify the reply author — skip if they liked their own comment.
+    if r.author_id != user.id:
+        await notify_dispatch(
+            db,
+            user_id=r.author_id,
+            type=NotificationType.LIKE,
+            title=f"{user.username} 赞了你的评论",
+            payload={
+                "reply_id": reply_id,
+                "post_id": r.post_id,
+                "actor_id": user.id,
+                "actor_name": user.username,
+            },
+        )
+
     try:
         await db.commit()
     except IntegrityError:

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -25,10 +25,9 @@ On connect:
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import logging
-from typing import Any
 
 from fastapi import (
     APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect, status,
@@ -38,24 +37,12 @@ from sqlalchemy import func, select, update
 from app.core.database import AsyncSessionLocal
 from app.core.deps import CurrentUser, DB
 from app.core.ws import manager
-from app.models.notification import Notification, NotificationType
+from app.models.notification import Notification
 from app.services.auth import AuthError, get_current_user
 
 log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["notifications"])
-
-
-# ─── Helpers ────────────────────────────────────────────────────────────────
-def _serialize(n: Notification) -> dict[str, Any]:
-    return {
-        "id": n.id,
-        "type": n.type.value,
-        "title": n.title,
-        "payload": n.payload,
-        "read": n.read_at is not None,
-        "created_at": n.created_at.isoformat() if n.created_at else None,
-    }
 
 
 # ─── REST endpoints ────────────────────────────────────────────────────────
@@ -83,7 +70,7 @@ async def list_notifications(
 
     return {
         "page": page, "page_size": page_size, "total": total,
-        "notifications": [_serialize(n) for n in rows],
+        "notifications": [n.to_dict() for n in rows],
     }
 
 
@@ -107,9 +94,9 @@ async def mark_read(notification_id: int, db: DB, user: CurrentUser):
     if n is None:
         raise HTTPException(status_code=404, detail="notification not found")
     if n.read_at is None:
-        n.read_at = datetime.utcnow()
+        n.read_at = datetime.now(timezone.utc)
         await db.flush()
-    return _serialize(n)
+    return n.to_dict()
 
 
 @router.patch("/notifications/read-all")
@@ -118,7 +105,7 @@ async def mark_all_read(db: DB, user: CurrentUser):
     result = await db.execute(
         update(Notification)
         .where(Notification.user_id == user.id, Notification.read_at.is_(None))
-        .values(read_at=datetime.utcnow())
+        .values(read_at=datetime.now(timezone.utc))
     )
     return {"updated": result.rowcount or 0}
 
@@ -152,7 +139,7 @@ async def ws_notifications(websocket: WebSocket, token: str = Query(...)):
         if rows:
             backlog = {
                 "kind": "backlog",
-                "notifications": [_serialize(n) for n in rows],
+                "notifications": [n.to_dict() for n in rows],
             }
             await websocket.send_text(
                 json.dumps(backlog, ensure_ascii=False, default=str)
@@ -205,7 +192,7 @@ async def _mark_read_background(user_id: int, notification_id: int) -> None:
                     Notification.user_id == user_id,
                     Notification.read_at.is_(None),
                 )
-                .values(read_at=datetime.utcnow())
+                .values(read_at=datetime.now(timezone.utc))
             )
             await session.commit()
     except Exception as exc:  # noqa: BLE001

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,212 @@
+"""Notifications — REST + WebSocket.
+
+REST (under Bearer auth):
+  GET    /api/v1/notifications                list (paginated; filter unread)
+  GET    /api/v1/notifications/unread-count   int
+  PATCH  /api/v1/notifications/{id}/read      mark one read
+  PATCH  /api/v1/notifications/read-all       mark everything read
+
+WebSocket:
+  WS     /api/v1/ws/notifications?token=<access_token>
+
+Auth on WS: the browser EventSource/WebSocket API can't easily set the
+Authorization header for raw ws:// upgrades, so we accept the access
+token via query param. Same token, same validator, just a different
+carrier. We resolve the user *before* ws.accept() so an invalid token
+gets a clean 1008 close.
+
+On connect:
+  1. validate token → user
+  2. accept socket + register with ConnectionManager
+  3. flush any unread notifications created before now (offline backlog)
+  4. idle — live pushes come via notify.dispatch()
+  5. read client frames for heartbeat ping + client-originated `ack:{id}`
+     that marks a notification read without a REST roundtrip.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import logging
+from typing import Any
+
+from fastapi import (
+    APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect, status,
+)
+from sqlalchemy import func, select, update
+
+from app.core.database import AsyncSessionLocal
+from app.core.deps import CurrentUser, DB
+from app.core.ws import manager
+from app.models.notification import Notification, NotificationType
+from app.services.auth import AuthError, get_current_user
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["notifications"])
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+def _serialize(n: Notification) -> dict[str, Any]:
+    return {
+        "id": n.id,
+        "type": n.type.value,
+        "title": n.title,
+        "payload": n.payload,
+        "read": n.read_at is not None,
+        "created_at": n.created_at.isoformat() if n.created_at else None,
+    }
+
+
+# ─── REST endpoints ────────────────────────────────────────────────────────
+@router.get("/notifications")
+async def list_notifications(
+    db: DB,
+    user: CurrentUser,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    unread_only: bool = False,
+):
+    q = select(Notification).where(Notification.user_id == user.id)
+    if unread_only:
+        q = q.where(Notification.read_at.is_(None))
+
+    total_q = select(func.count()).select_from(Notification).where(Notification.user_id == user.id)
+    if unread_only:
+        total_q = total_q.where(Notification.read_at.is_(None))
+    total = (await db.execute(total_q)).scalar_one()
+
+    rows = (await db.execute(
+        q.order_by(Notification.created_at.desc())
+         .offset((page - 1) * page_size).limit(page_size)
+    )).scalars().all()
+
+    return {
+        "page": page, "page_size": page_size, "total": total,
+        "notifications": [_serialize(n) for n in rows],
+    }
+
+
+@router.get("/notifications/unread-count")
+async def unread_count(db: DB, user: CurrentUser):
+    total = (await db.execute(
+        select(func.count()).select_from(Notification)
+        .where(Notification.user_id == user.id, Notification.read_at.is_(None))
+    )).scalar_one()
+    return {"unread": total}
+
+
+@router.patch("/notifications/{notification_id}/read")
+async def mark_read(notification_id: int, db: DB, user: CurrentUser):
+    n = (await db.execute(
+        select(Notification).where(
+            Notification.id == notification_id,
+            Notification.user_id == user.id,
+        )
+    )).scalar_one_or_none()
+    if n is None:
+        raise HTTPException(status_code=404, detail="notification not found")
+    if n.read_at is None:
+        n.read_at = datetime.utcnow()
+        await db.flush()
+    return _serialize(n)
+
+
+@router.patch("/notifications/read-all")
+async def mark_all_read(db: DB, user: CurrentUser):
+    # Single UPDATE — avoids loading every row.
+    result = await db.execute(
+        update(Notification)
+        .where(Notification.user_id == user.id, Notification.read_at.is_(None))
+        .values(read_at=datetime.utcnow())
+    )
+    return {"updated": result.rowcount or 0}
+
+
+# ─── WebSocket endpoint ────────────────────────────────────────────────────
+@router.websocket("/ws/notifications")
+async def ws_notifications(websocket: WebSocket, token: str = Query(...)):
+    # 1. Auth before accept — invalid tokens get closed cleanly.
+    async with AsyncSessionLocal() as session:
+        try:
+            user = await get_current_user(session, token)
+        except AuthError:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+    # 2. Accept + register.
+    await websocket.accept()
+    await manager.connect(user.id, websocket)
+    log.info("WS connected: user=%s online=%d", user.id, manager.online_count())
+
+    try:
+        # 3. Offline backlog — flush unread notifications the user missed.
+        async with AsyncSessionLocal() as session:
+            rows = (await session.execute(
+                select(Notification)
+                .where(Notification.user_id == user.id, Notification.read_at.is_(None))
+                .order_by(Notification.created_at.asc())
+                .limit(200)  # cap — if they've accumulated more, list API fills the rest
+            )).scalars().all()
+
+        if rows:
+            backlog = {
+                "kind": "backlog",
+                "notifications": [_serialize(n) for n in rows],
+            }
+            await websocket.send_text(
+                json.dumps(backlog, ensure_ascii=False, default=str)
+            )
+
+        # 4. Main loop — read client frames for heartbeat + ack.
+        while True:
+            raw = await websocket.receive_text()
+            msg = _parse_client_frame(raw)
+            if msg is None:
+                continue
+            op = msg.get("op")
+            if op == "ping":
+                await websocket.send_text(json.dumps({"kind": "pong"}))
+            elif op == "ack":
+                # Client-originated mark-read — saves a REST roundtrip.
+                nid = msg.get("id")
+                if isinstance(nid, int):
+                    await _mark_read_background(user.id, nid)
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        log.info("WS closing for user=%s: %s", user.id, exc)
+    finally:
+        await manager.disconnect(user.id, websocket)
+        log.info("WS disconnected: user=%s online=%d", user.id, manager.online_count())
+
+
+def _parse_client_frame(raw: str) -> dict | None:
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+async def _mark_read_background(user_id: int, notification_id: int) -> None:
+    """Mark one notification as read without touching the WS session.
+
+    Fire-and-forget from the WS loop; errors are swallowed (the REST
+    endpoint exists as a fallback).
+    """
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(
+                update(Notification)
+                .where(
+                    Notification.id == notification_id,
+                    Notification.user_id == user_id,
+                    Notification.read_at.is_(None),
+                )
+                .values(read_at=datetime.utcnow())
+            )
+            await session.commit()
+    except Exception as exc:  # noqa: BLE001
+        log.info("WS-ack mark_read failed: %s", exc)

--- a/backend/app/services/notify.py
+++ b/backend/app/services/notify.py
@@ -53,20 +53,9 @@ async def dispatch(
     try:
         await manager.send_to_user(user_id, {
             "kind": "notification",
-            "data": _serialize(n),
+            "data": n.to_dict(),
         })
     except Exception as exc:  # noqa: BLE001
         log.warning("live push failed for user=%s: %s", user_id, exc)
 
     return n
-
-
-def _serialize(n: Notification) -> dict[str, Any]:
-    return {
-        "id": n.id,
-        "type": n.type.value,
-        "title": n.title,
-        "payload": n.payload,
-        "read": n.read_at is not None,
-        "created_at": n.created_at.isoformat() if n.created_at else None,
-    }

--- a/backend/app/services/notify.py
+++ b/backend/app/services/notify.py
@@ -1,0 +1,72 @@
+"""Notification dispatch.
+
+Produces a single entry point `dispatch(db, user_id, type, payload, title)`
+that:
+  1. Inserts a row into the `notifications` table (durable — backfills
+     on next WS connect if the user is offline).
+  2. Pushes the same payload over WebSocket if the user is online.
+
+Errors on step 2 are swallowed — the DB row is authoritative, and the
+user will receive it next time they connect. Same degradable pattern as
+ES / Neo4j.
+
+The DB insert is done inside the caller's transaction so the event only
+lands if the business write (reply create, like, etc.) also succeeded.
+Keep this function cheap and side-effect-clean.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.ws import manager
+from app.models.notification import Notification, NotificationType
+
+log = logging.getLogger(__name__)
+
+
+async def dispatch(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    type: NotificationType,
+    payload: dict[str, Any],
+    title: str | None = None,
+) -> Notification:
+    """Persist one notification and push it live if the recipient is online.
+
+    Caller owns the transaction — we only `db.add` + `flush`, the commit
+    lives with the business write (e.g. create_reply).
+    """
+    n = Notification(
+        user_id=user_id,
+        type=type,
+        payload=payload,
+        title=title,
+    )
+    db.add(n)
+    await db.flush()  # populate n.id + n.created_at
+
+    # Live push — cheap if nobody's listening, harmless if it fails.
+    try:
+        await manager.send_to_user(user_id, {
+            "kind": "notification",
+            "data": _serialize(n),
+        })
+    except Exception as exc:  # noqa: BLE001
+        log.warning("live push failed for user=%s: %s", user_id, exc)
+
+    return n
+
+
+def _serialize(n: Notification) -> dict[str, Any]:
+    return {
+        "id": n.id,
+        "type": n.type.value,
+        "title": n.title,
+        "payload": n.payload,
+        "read": n.read_at is not None,
+        "created_at": n.created_at.isoformat() if n.created_at else None,
+    }


### PR DESCRIPTION
## 关联 Issue

Closes #27 — US-025 社区实时通知（WebSocket）

## 做了什么

### 数据层
- `Notification` 模型：`user_id` / `type` enum / JSONB `payload` / `read_at` / `title`
- Alembic `0006_notifications.py`：含 `(user_id, created_at) WHERE read_at IS NULL` 的 partial index，优化 "该用户未读列表" 这个最高频查询
- 避开 0005 踩过的坑：不预先 `enum.create()`，直接让 `sa.Enum` 在 `create_table` 里处理生命周期

### WebSocket 传输层
- `core/ws.py`：`ConnectionManager` 单例，\`user_id → set[WebSocket]\` 内存索引，支持一个用户多标签/多端同时在线
- 多副本伸缩预留口子：接口不变的情况下，把 `_peers` 换成 Redis pub/sub 桥即可（单 replica 够用就先简单做）

### Dispatch
- `services/notify.py`：\`dispatch(db, user_id, type, payload, title)\` 单入口
  - 写 `notifications` 行（跟随调用方事务，业务写失败时自动回滚）
  - Best-effort WS 推送；推送失败吞异常 —— DB 行是权威来源，下次连接时补发

### REST
```
GET   /api/v1/notifications                分页 + unread_only 过滤
GET   /api/v1/notifications/unread-count
PATCH /api/v1/notifications/{id}/read
PATCH /api/v1/notifications/read-all       批量（一条 UPDATE，不逐行加载）
```

### WebSocket
```
WS /api/v1/ws/notifications?token=<access_token>
```
- Auth 走 query param：浏览器原生 WebSocket 不能设 Authorization header，只好把 token 放 URL。同一个 `get_current_user` validator，换个载体而已
- Auth 失败 → 1008 close（连 accept 都不走）
- 连上后先 flush 200 条未读的离线积压（背压情况下 REST list API 兜底）
- 客户端帧支持：`{"op":"ping"}` → pong；`{"op":"ack","id":N}` → fire-and-forget 标记已读（省 REST roundtrip）

### 业务事件接线
改 `routers/community.py`：
- \`create_reply\` → 同时处理三种 fan-out 并去重：
  1. Top-level reply → 通知帖子作者
  2. 嵌套 reply → 通知父 reply 作者（不再重复通知帖子作者，降噪）
  3. `@mention` 解析（正则支持中英文用户名） → 分别通知被提及者
- \`like_reply\` → 通知 reply 作者；自己点自己不通知
- 所有 recipient 用 `notified: set[int]` 去重，确保一条 reply 一个用户最多一条通知

## 范围控制 / 不在本 PR 内

- **`knowledge_update` 事件**：enum 已定义，但 KnowledgeItem 没有 owner 或 subscriber 列，没有合理的 recipient 集合。等订阅模型或 ownership 模型落地后再接（可能跟 #47 / US-071 一起）
- **多副本 fan-out**：当前 `ConnectionManager` 是进程内的，生产多 replica 部署时需要 Redis pub/sub 桥接。Raven 那边 #66 生产部署时应该考虑进去

## 完成标准自检

- [x] 实时通知延迟 < 1s：单进程内存 fan-out，实测路径只有 1 次 JSON encode + 1 次 \`send_text\`，远低于 1s
- [x] 断线重连正常工作：客户端重新发起 WS 连接，`connect` → backlog flush → live 流；离线期间产生的通知通过 `read_at IS NULL` 过滤补发

## Reviewer 注意

- `create_reply` 里我加了 \`await db.flush()\`，原因是 notification payload 需要 \`r.id\`。之前版本没 flush 是因为不需要 id
- \`_MENTION_RE\` 正则偏宽松（`\\w + CJK`），靠 DB username 查找做真正过滤。不觉得需要前置长度限制
- WS 端点没走 `Depends(current_user)`，因为那个是 HTTP 专用；这里显式在函数体里调 `get_current_user` + `AsyncSessionLocal`