### PR TITLE
feat: #35 share records soft-delete with 30-day recovery

### DIFF
--- a/backend/alembic/versions/0006_sharing_soft_delete.py
+++ b/backend/alembic/versions/0006_sharing_soft_delete.py
@@ -1,0 +1,44 @@
+"""sharing_records — soft delete with 30-day recovery window.
+
+Revision ID: 0006_sharing_soft_delete
+Revises: 0005
+Create Date: 2026-04-18
+
+Adds `deleted_at` to `sharing_records` so revoke becomes reversible for 30
+days. The Celery beat task `ekm.sharing.purge_expired` hard-deletes rows
+whose `deleted_at` is older than that window.
+
+Note: picked a literal revision ID rather than `0006` so the migration
+graph stays deterministic if another parallel PR also numbers at 0006 —
+whoever merges second just updates `down_revision` during rebase.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0006_sharing_soft_delete"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sharing_records",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Plain index is fine — the purge scan uses `WHERE deleted_at < cutoff`,
+    # and the active-list query uses `WHERE deleted_at IS NULL` which already
+    # benefits from the NULLs-last B-tree default.
+    op.create_index(
+        "ix_sharing_records_deleted_at",
+        "sharing_records",
+        ["deleted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sharing_records_deleted_at", table_name="sharing_records")
+    op.drop_column("sharing_records", "deleted_at")

--- a/backend/alembic/versions/0007_sharing_soft_delete.py
+++ b/backend/alembic/versions/0007_sharing_soft_delete.py
@@ -1,16 +1,15 @@
 """sharing_records — soft delete with 30-day recovery window.
 
-Revision ID: 0006_sharing_soft_delete
-Revises: 0005
+Revision ID: 0007_sharing_soft_delete
+Revises: 0006
 Create Date: 2026-04-18
 
 Adds `deleted_at` to `sharing_records` so revoke becomes reversible for 30
 days. The Celery beat task `ekm.sharing.purge_expired` hard-deletes rows
 whose `deleted_at` is older than that window.
 
-Note: picked a literal revision ID rather than `0006` so the migration
-graph stays deterministic if another parallel PR also numbers at 0006 —
-whoever merges second just updates `down_revision` during rebase.
+Renumbered from 0006 → 0007 on rebase: #85 (notifications) shipped first
+at 0006. Keeping the migration graph linear.
 """
 from typing import Sequence, Union
 
@@ -18,8 +17,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "0006_sharing_soft_delete"
-down_revision: Union[str, None] = "0005"
+revision: str = "0007_sharing_soft_delete"
+down_revision: Union[str, None] = "0006"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/models/sharing.py
+++ b/backend/app/models/sharing.py
@@ -37,6 +37,10 @@ class SharingRecord(Base):
     token: Mapped[str | None] = mapped_column(String(255), unique=True, index=True, nullable=True)  # public link token
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    # Soft-delete: NULL means active. Set to revoke-time; the owner can restore
+    # within 30 days. A Celery beat task purges rows whose deleted_at is older
+    # than the retention window.
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
 
     knowledge_item: Mapped["KnowledgeItem"] = relationship("KnowledgeItem", back_populates="sharing_records")  # noqa: F821
     shared_by: Mapped["User"] = relationship("User", foreign_keys=[shared_by_id], back_populates="sharing_records")  # noqa: F821

--- a/backend/app/routers/sharing.py
+++ b/backend/app/routers/sharing.py
@@ -1,4 +1,13 @@
-from fastapi import APIRouter, HTTPException, Request, status
+"""Sharing records — create, list, revoke (soft), restore, and public access.
+
+Revoke is soft: `DELETE /api/v1/sharing/{id}` sets `deleted_at` instead of
+removing the row. The record stays in the DB for `RETENTION_DAYS` so the
+owner can `POST /api/v1/sharing/{id}/restore` on it. After that the
+Celery beat task `ekm.sharing.purge_expired` hard-deletes it.
+"""
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, DB
@@ -8,7 +17,14 @@ from app.schemas.sharing import (
     PublicAccessResponse,
     ShareResponse,
 )
-from app.services.sharing import SharingError, create_share, resolve_public_token
+from app.services.sharing import (
+    RETENTION_DAYS,
+    SharingError,
+    create_share,
+    resolve_public_token,
+    restore_share,
+    soft_delete_share,
+)
 
 router = APIRouter(prefix="/api/v1/sharing", tags=["sharing"])
 
@@ -18,6 +34,14 @@ def _build_response(record: SharingRecord, request: Request) -> ShareResponse:
     if record.token:
         base = str(request.base_url).rstrip("/")
         public_url = f"{base}/api/v1/sharing/public/{record.token}"
+    # Compute restore window remaining (rounded up so "0 days" only shows
+    # on the exact expiry instant; UIs showing "X天后自动删除" want generous
+    # rounding).
+    restore_days_left: int | None = None
+    if record.deleted_at is not None:
+        elapsed = datetime.now(timezone.utc) - record.deleted_at
+        remaining = timedelta(days=RETENTION_DAYS) - elapsed
+        restore_days_left = max(0, (remaining.days + (1 if remaining.seconds or remaining.microseconds else 0)))
     return ShareResponse(
         id=record.id,
         knowledge_item_id=record.knowledge_item_id,
@@ -29,7 +53,26 @@ def _build_response(record: SharingRecord, request: Request) -> ShareResponse:
         public_url=public_url,
         expires_at=record.expires_at,
         created_at=record.created_at,
+        deleted_at=record.deleted_at,
+        is_deleted=record.deleted_at is not None,
+        restore_days_left=restore_days_left,
     )
+
+
+async def _load_owned_share(db, share_id: int, user) -> SharingRecord:
+    result = await db.execute(
+        select(SharingRecord).where(
+            SharingRecord.id == share_id,
+            SharingRecord.shared_by_id == user.id,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="分享记录不存在或无权操作",
+        )
+    return record
 
 
 @router.post(
@@ -58,28 +101,89 @@ async def create(
 @router.get(
     "/",
     response_model=list[ShareResponse],
-    summary="列出当前用户发出的分享",
+    summary="列出当前用户发出的分享（默认仅活跃记录）",
 )
 async def list_my_shares(
     request: Request,
     db: DB = None,
     user: CurrentUser = None,
+    include_deleted: bool = Query(
+        False,
+        description="true 则连同已软删除记录一并返回；多数场景用默认 false",
+    ),
 ):
-    result = await db.execute(
-        select(SharingRecord).where(SharingRecord.shared_by_id == user.id).order_by(SharingRecord.created_at.desc())
-    )
+    stmt = select(SharingRecord).where(SharingRecord.shared_by_id == user.id)
+    if not include_deleted:
+        stmt = stmt.where(SharingRecord.deleted_at.is_(None))
+    stmt = stmt.order_by(SharingRecord.created_at.desc())
+    result = await db.execute(stmt)
     records = result.scalars().all()
     return [_build_response(r, request) for r in records]
 
 
-@router.delete("/{share_id}", status_code=status.HTTP_204_NO_CONTENT, summary="撤销分享")
+@router.get(
+    "/trash",
+    response_model=list[ShareResponse],
+    summary="列出仍在恢复窗口内（30天）的已撤销分享",
+)
+async def list_trash(
+    request: Request,
+    db: DB = None,
+    user: CurrentUser = None,
+):
+    # Explicit cutoff filter — belt & braces against rows that somehow
+    # survived the purge task (e.g. beat outage). Hiding already-expired
+    # records here avoids the UI offering a "Restore" button that will
+    # then fail with RESTORE_WINDOW_EXPIRED.
+    cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    stmt = (
+        select(SharingRecord)
+        .where(
+            SharingRecord.shared_by_id == user.id,
+            SharingRecord.deleted_at.is_not(None),
+            SharingRecord.deleted_at >= cutoff,
+        )
+        .order_by(SharingRecord.deleted_at.desc())
+    )
+    result = await db.execute(stmt)
+    records = result.scalars().all()
+    return [_build_response(r, request) for r in records]
+
+
+@router.delete(
+    "/{share_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="撤销分享（软删除，30天内可恢复）",
+)
 async def revoke(share_id: int, db: DB = None, user: CurrentUser = None):
-    result = await db.execute(select(SharingRecord).where(SharingRecord.id == share_id, SharingRecord.shared_by_id == user.id))
-    record = result.scalar_one_or_none()
-    if not record:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="分享记录不存在或无权操作")
-    await db.delete(record)
+    record = await _load_owned_share(db, share_id, user)
+    await soft_delete_share(db, record)
     await db.commit()
+
+
+@router.post(
+    "/{share_id}/restore",
+    response_model=ShareResponse,
+    summary="恢复已撤销的分享（仅 30 天内有效）",
+)
+async def restore(
+    share_id: int,
+    request: Request,
+    db: DB = None,
+    user: CurrentUser = None,
+):
+    record = await _load_owned_share(db, share_id, user)
+    try:
+        await restore_share(db, record)
+    except SharingError as e:
+        # RESTORE_WINDOW_EXPIRED → 410 Gone (resource existed but is no
+        # longer recoverable). Matches how we signal expired public links.
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE if e.code == "RESTORE_WINDOW_EXPIRED" else status.HTTP_400_BAD_REQUEST,
+            detail={"code": e.code, "message": e.message},
+        )
+    await db.commit()
+    return _build_response(record, request)
 
 
 @router.get(

--- a/backend/app/schemas/sharing.py
+++ b/backend/app/schemas/sharing.py
@@ -46,6 +46,13 @@ class ShareResponse(BaseModel):
     public_url: str | None   # constructed by router
     expires_at: datetime | None
     created_at: datetime
+    # Soft-delete metadata — `is_deleted` is redundant with `deleted_at`
+    # but cheap, and saves the client a null-check when it only wants to
+    # render status pills.
+    deleted_at: datetime | None = None
+    is_deleted: bool = False
+    # Present only on trash listings; days remaining before auto-purge.
+    restore_days_left: int | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/sharing.py
+++ b/backend/app/services/sharing.py
@@ -11,6 +11,12 @@ from app.models.user import User
 from app.schemas.sharing import CreateShareRequest, ShareTarget
 
 
+# How long a soft-deleted share stays recoverable before the purge task
+# hard-deletes it. Single source of truth — the Celery task and the router
+# both import this.
+RETENTION_DAYS = 30
+
+
 class SharingError(Exception):
     def __init__(self, message: str, code: str = "SHARING_ERROR"):
         self.message = message
@@ -58,12 +64,46 @@ async def create_share(
 
 
 async def resolve_public_token(db: AsyncSession, token: str) -> SharingRecord:
-    result = await db.execute(select(SharingRecord).where(SharingRecord.token == token))
+    result = await db.execute(
+        select(SharingRecord).where(
+            SharingRecord.token == token,
+            SharingRecord.deleted_at.is_(None),  # revoked links 404
+        )
+    )
     record: SharingRecord | None = result.scalar_one_or_none()
     if not record:
         raise SharingError("分享链接无效", "INVALID_TOKEN")
     if record.expires_at and record.expires_at < datetime.now(timezone.utc):
         raise SharingError("分享链接已过期", "TOKEN_EXPIRED")
+    return record
+
+
+async def soft_delete_share(db: AsyncSession, record: SharingRecord) -> SharingRecord:
+    """Mark a share as deleted without removing the row.
+
+    Idempotent — re-revoking a soft-deleted record does not reset the
+    clock, which would extend the user's recovery window unfairly.
+    """
+    if record.deleted_at is None:
+        record.deleted_at = datetime.now(timezone.utc)
+        await db.flush()
+    return record
+
+
+async def restore_share(db: AsyncSession, record: SharingRecord) -> SharingRecord:
+    """Clear the soft-delete marker if still within the retention window.
+
+    Raises SharingError(\"RESTORE_WINDOW_EXPIRED\") if the window has elapsed
+    — at that point the row is only waiting for the purge task to sweep it,
+    and the user would get inconsistent behaviour otherwise.
+    """
+    if record.deleted_at is None:
+        return record  # already active, no-op
+    cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    if record.deleted_at < cutoff:
+        raise SharingError("恢复窗口已过期", "RESTORE_WINDOW_EXPIRED")
+    record.deleted_at = None
+    await db.flush()
     return record
 
 
@@ -79,6 +119,7 @@ async def check_user_access(
     result = await db.execute(
         select(SharingRecord).where(
             SharingRecord.knowledge_item_id == knowledge_item_id,
+            SharingRecord.deleted_at.is_(None),   # revoked shares never grant access
             (
                 (SharingRecord.shared_to_user_id == user.id)
                 | (SharingRecord.shared_to_department == user.department)

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -13,6 +13,7 @@ Or via compose:
 from __future__ import annotations
 
 from celery import Celery
+from celery.schedules import crontab
 
 from app.core.config import settings
 
@@ -44,4 +45,14 @@ celery_app.conf.update(
     # Prefetch 1 so a slow parse doesn't starve other workers.
     worker_prefetch_multiplier=1,
     task_acks_late=True,
+
+    # Periodic jobs — requires running `celery beat` alongside the worker:
+    #     celery -A app.worker.celery_app beat --loglevel=info
+    # See docker-compose.yml `beat` service (profile: worker).
+    beat_schedule={
+        "sharing-purge-expired-daily": {
+            "task": "ekm.sharing.purge_expired",
+            "schedule": crontab(hour=3, minute=17),  # 03:17 UTC — off-peak
+        },
+    },
 )

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -92,6 +92,36 @@ def index_to_es(self, document_id: int) -> dict[str, Any]:
     return {"document_id": document_id, "indexed_chunks": indexed, "status": "indexed"}
 
 
+@celery_app.task(name="ekm.sharing.purge_expired", bind=True)
+def purge_expired_shares(self) -> dict[str, Any]:
+    """Hard-delete sharing_records whose deleted_at exceeds the retention
+    window. Runs daily via beat; safe to invoke manually.
+
+    The service layer's SharingError(\"RESTORE_WINDOW_EXPIRED\") already
+    prevents users from touching these rows, so we can remove them without
+    coordinating with live requests.
+    """
+    from datetime import datetime, timedelta, timezone
+    from sqlalchemy import delete as sa_delete
+    from app.services.document_parse import SyncSession
+    from app.services.sharing import RETENTION_DAYS
+    from app.models.sharing import SharingRecord
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    with SyncSession() as db:
+        result = db.execute(
+            sa_delete(SharingRecord).where(
+                SharingRecord.deleted_at.is_not(None),
+                SharingRecord.deleted_at < cutoff,
+            )
+        )
+        purged = result.rowcount or 0
+        db.commit()
+
+    log.info("purge_expired_shares cutoff=%s purged=%d", cutoff.isoformat(), purged)
+    return {"cutoff": cutoff.isoformat(), "purged": purged, "status": "ok"}
+
+
 @celery_app.task(name="ekm.docs.vectorize", bind=True, max_retries=3, default_retry_delay=60)
 def vectorize_chunks(self, document_id: int) -> dict[str, Any]:
     """Embed each DocumentChunk + upsert to Qdrant. Idempotent on re-run."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,23 @@ services:
     restart: unless-stopped
     profiles: ["worker"]   # opt-in: `docker compose --profile worker up`
 
+  # ── Celery beat (periodic tasks) ──────────────────────────────────────
+  # Kicks off scheduled jobs like ekm.sharing.purge_expired. Separate from
+  # the worker process: beat enqueues, workers execute. One beat per
+  # deployment; running multiple beats would fire each job N times.
+  beat:
+    build: ./backend
+    command: ["celery", "-A", "app.worker.celery_app", "beat", "--loglevel=info"]
+    env_file:
+      - ./backend/.env
+    volumes:
+      - ./backend:/app
+    depends_on:
+      redis:         { condition: service_healthy }
+      postgres:      { condition: service_healthy }
+    restart: unless-stopped
+    profiles: ["worker"]   # same profile as worker
+
 volumes:
   pg_data:
   es_data:


### PR DESCRIPTION
Closes #35

## 需求回顾（US-012）
- 分享记录列表（分享人/被分享人/时间/状态）
- 软删除：保留 30 天可恢复
- 过期自动硬删除（Celery 定时任务）

## 数据层
`sharing_records` 增加 `deleted_at` 字段（nullable，带普通 B-tree 索引）。
- NULL = 活跃
- 非 NULL = 已撤销，30 天内可恢复，之后被 beat 任务硬删

迁移：`alembic/versions/0006_sharing_soft_delete.py`

**关于迁移编号**：这个 PR 和 #85（#27 notifications）都从 main@`5d43ed1` 分叉、都用 0006。先 merge 哪个就那个保留 0006；后 merge 的会在 rebase 时改成 0007，graph 保持线性。Raven 可以选择性 squash/coordinate。

## 服务层（`services/sharing.py`）
- `RETENTION_DAYS = 30` —— 单一来源，router 和 celery 任务都引用
- `soft_delete_share(db, record)` —— 幂等；对已软删记录不重置时钟
- `restore_share(db, record)` —— 窗口外抛 `SharingError("RESTORE_WINDOW_EXPIRED")`
- `resolve_public_token`：过滤 `deleted_at IS NULL`（撤销后的 public 链接立即失效）
- `check_user_access`：同样过滤软删记录（防权限穿透）

## 接口层（`routers/sharing.py`）
| 方法 | 路径 | 行为 |
|------|------|------|
| POST | `/api/v1/sharing/` | 创建（不变） |
| GET | `/api/v1/sharing/` | 列表（默认只返活跃，加 `?include_deleted=true` 看全部） |
| GET | `/api/v1/sharing/trash` | 回收站（30 天内可恢复，按 `deleted_at` 降序） |
| DELETE | `/api/v1/sharing/{id}` | **改为软删** —— 204 |
| POST | `/api/v1/sharing/{id}/restore` | 恢复 —— 窗口外返回 410 Gone |
| GET | `/api/v1/sharing/public/{token}` | 公共访问（不变，但会校验 deleted_at） |

响应体扩展：`deleted_at` / `is_deleted` / `restore_days_left`（trash 列表用）。

## 定时任务
- `worker/tasks.py::purge_expired_shares` —— 扫 `deleted_at < now - 30d` 一次性 DELETE
- `celery_app.py::beat_schedule` —— `crontab(hour=3, minute=17)` 每天 03:17 UTC
- `docker-compose.yml` 新增 `beat` service（profile=worker，和 worker 同开关）

**部署注意**（Raven）：每个部署只能跑一个 beat 进程，多 beat 会重复触发任务。Fly 上建议用单独的 Machine 起 beat（不是用 worker Machine 加参数）。

## 权衡与取舍
- **检查顺序**：`restore_share` 先检查 `deleted_at is None`（幂等返回），再检查窗口 —— 避免"已经是活跃状态但因为 clock skew 判定过期"这种误判
- **`check_user_access` 对 public token**：现在统一以 `deleted_at IS NULL` 过滤。之前它不看 deleted_at，revoke 后 owner 依然可能被判定为"有权"（因为 owner_fallback 在最后）—— 但公开链接访问者会失权。现在语义统一。
- **`restore_days_left`** 只在列表/trash 响应里出现，不走 server-push —— 客户端刷新自然拿到最新值，不引入额外通知通道
- **beat schedule 打 03:17**：不落在整点避免和其他潜在 beat 冲突；UTC 凌晨是业务低谷

## 完成标准自检
- ✅ 分享记录列表含 shared_by / shared_to / time / status（`is_deleted` 字段）
- ✅ 软删除 30 天内可恢复（`POST /{id}/restore`）
- ✅ 过期自动硬删除（`ekm.sharing.purge_expired` + beat）
- ✅ 幂等：重复撤销不重置时钟；重复恢复不报错
- ✅ 公开链接 revoke 后立即失效
- ✅ py_compile 通过

## 后续 follow-ups（不在本 PR）
- 通知（#58 审批流）：revoke 后通知被分享人 —— 走 #27 的 notify.dispatch，等 #85 merge 后接一下
- 审计（AuditLog）：revoke/restore 写 `audit_logs`，等 #59 RBAC 落地后一起加