### PR TITLE
feat: #58 archive restore approval flow + notifications

### DIFF
--- a/backend/alembic/versions/0009_restore_requests.py
+++ b/backend/alembic/versions/0009_restore_requests.py
@@ -1,0 +1,138 @@
+"""archive restore requests + KM_OPS role + restore notification types.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-19
+
+US-060/062: let users ask for archived knowledge back, let KM Ops approve
+or reject. Single immutable row per request — reviewed_* columns get set
+in-place on decision. That row *is* the audit log.
+
+Adds:
+  - 'km_ops' value on existing `userrole` enum
+  - 3 values on existing `notification_type` enum
+    (restore_request_submitted / _approved / _rejected)
+  - new `restore_status` enum (pending / approved / rejected)
+  - `archive_restore_requests` table
+
+Renumbered 0008 → 0009 on rebase: #87 (archive rules) shipped first and
+took 0008. Chaining linearly from there. Same "loser rebases" pattern
+we ran on #86/#87 last cycle.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: Union[str, None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Extend existing enums — additive, safe.
+    #    ALTER TYPE ... ADD VALUE can't run inside a txn block, so commit
+    #    the migration's own txn first. IF NOT EXISTS keeps reruns idempotent.
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'km_ops'")
+    op.execute(
+        "ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'restore_request_submitted'"
+    )
+    op.execute(
+        "ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'restore_request_approved'"
+    )
+    op.execute(
+        "ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'restore_request_rejected'"
+    )
+
+    # 2. New restore_status enum — create_type=True because it's brand new.
+    restore_status = sa.Enum(
+        "pending", "approved", "rejected",
+        name="restore_status",
+    )
+    restore_status.create(op.get_bind(), checkfirst=True)
+
+    # 3. archive_restore_requests table.
+    op.create_table(
+        "archive_restore_requests",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "knowledge_item_id", sa.Integer(),
+            # CASCADE — if the item is permanently destroyed, requests
+            # for it are meaningless. (Soft-delete via is_archived does
+            # NOT trigger this; only true row-level delete does.)
+            sa.ForeignKey("knowledge_items.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "submitted_by_id", sa.Integer(),
+            # RESTRICT — preserve audit trail even if a user leaves; an
+            # admin must re-home or anonymize their requests explicitly.
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "submitted_at", sa.DateTime(timezone=True),
+            server_default=sa.func.now(), nullable=False,
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending", "approved", "rejected",
+                name="restore_status",
+                create_type=False,  # created above
+            ),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "reviewed_by_id", sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=True,
+        ),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("review_note", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_archive_restore_requests_knowledge_item_id",
+        "archive_restore_requests", ["knowledge_item_id"],
+    )
+    op.create_index(
+        "ix_archive_restore_requests_submitted_by_id",
+        "archive_restore_requests", ["submitted_by_id"],
+    )
+    op.create_index(
+        "ix_archive_restore_requests_reviewed_by_id",
+        "archive_restore_requests", ["reviewed_by_id"],
+    )
+    op.create_index(
+        "ix_archive_restore_requests_status",
+        "archive_restore_requests", ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_archive_restore_requests_status",
+        table_name="archive_restore_requests",
+    )
+    op.drop_index(
+        "ix_archive_restore_requests_reviewed_by_id",
+        table_name="archive_restore_requests",
+    )
+    op.drop_index(
+        "ix_archive_restore_requests_submitted_by_id",
+        table_name="archive_restore_requests",
+    )
+    op.drop_index(
+        "ix_archive_restore_requests_knowledge_item_id",
+        table_name="archive_restore_requests",
+    )
+    op.drop_table("archive_restore_requests")
+    sa.Enum(name="restore_status").drop(op.get_bind(), checkfirst=True)
+    # Postgres can't DROP VALUE from an enum. The extended values on
+    # userrole / notification_type stay — harmless, and avoids the
+    # "can't drop an enum value in use" class of problems. Same caveat
+    # we documented on 0006 and 0008 (#87).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.routers import feedback
 from app.routers import graph as graph_router
 from app.routers import notifications
 from app.routers import archive as archive_router
+from app.routers import restore as restore_router
 
 
 @asynccontextmanager
@@ -96,6 +97,7 @@ for _r in feedback.routers:
 app.include_router(graph_router.router)
 app.include_router(notifications.router)
 app.include_router(archive_router.router)
+app.include_router(restore_router.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.community import Post, Reply, ReplyLike
 from app.models.feedback import ChatFeedback, FeedbackRating
 from app.models.notification import Notification, NotificationType
 from app.models.archive import ArchiveRule
+from app.models.restore import ArchiveRestoreRequest, RestoreStatus
 
 __all__ = [
     "User", "UserRole",
@@ -20,4 +21,5 @@ __all__ = [
     "ChatFeedback", "FeedbackRating",
     "Notification", "NotificationType",
     "ArchiveRule",
+    "ArchiveRestoreRequest", "RestoreStatus",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -28,12 +28,15 @@ from app.core.database import Base
 
 
 class NotificationType(str, enum.Enum):
-    COMMENT           = "comment"            # new reply on your post
-    LIKE              = "like"               # someone liked your reply
-    MENTION           = "mention"            # @user in a reply
-    KNOWLEDGE_UPDATE  = "knowledge_update"   # doc you care about changed
-    ARCHIVE_REMINDER  = "archive_reminder"   # your doc will auto-archive soon
-    AUTO_ARCHIVED     = "auto_archived"      # your doc was just auto-archived
+    COMMENT                    = "comment"                    # new reply on your post
+    LIKE                       = "like"                       # someone liked your reply
+    MENTION                    = "mention"                    # @user in a reply
+    KNOWLEDGE_UPDATE           = "knowledge_update"           # doc you care about changed
+    ARCHIVE_REMINDER           = "archive_reminder"           # your doc will auto-archive soon
+    AUTO_ARCHIVED              = "auto_archived"              # your doc was just auto-archived
+    RESTORE_REQUEST_SUBMITTED  = "restore_request_submitted"  # to KM Ops: new request to review
+    RESTORE_REQUEST_APPROVED   = "restore_request_approved"   # to submitter: your doc is back
+    RESTORE_REQUEST_REJECTED   = "restore_request_rejected"   # to submitter: with reason
 
 
 class Notification(Base):

--- a/backend/app/models/restore.py
+++ b/backend/app/models/restore.py
@@ -1,0 +1,113 @@
+"""Archive restore requests (US-060/062).
+
+Flow:
+  1. User submits an ArchiveRestoreRequest for a knowledge item they
+     want back from the archive (typically one they authored, but the
+     router decides authorization — model stays dumb).
+  2. KM Ops (UserRole.KM_OPS or ADMIN) reviews and approves/rejects,
+     optionally with a review_note. The status transition happens on
+     the same row — we never mutate a reviewed request again, so each
+     row is effectively immutable after review. That gives us a free
+     audit log without a side table.
+  3. On approval: un-archive the item (is_archived=False, archived_at=
+     NULL, archive_reminder_sent_at=NULL so the window restarts fresh),
+     notify submitter. On rejection: just notify.
+
+Two FKs point at `users` (submitter + reviewer), so relationships
+declare `foreign_keys=` explicitly — SQLAlchemy can't guess otherwise.
+"""
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime, Enum, ForeignKey, Integer, Text, func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class RestoreStatus(str, enum.Enum):
+    PENDING  = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class ArchiveRestoreRequest(Base):
+    __tablename__ = "archive_restore_requests"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+
+    # The archived knowledge item the user wants back. CASCADE because
+    # if the item is permanently destroyed the request history for it
+    # is meaningless.
+    knowledge_item_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("knowledge_items.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+
+    # Submitter — who wants it back. RESTRICT: keep the audit trail
+    # accurate even if a user is later deleted (admin must re-home
+    # their requests explicitly).
+    submitted_by_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False, index=True,
+    )
+    submitted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    status: Mapped[RestoreStatus] = mapped_column(
+        # Same values_callable pattern we use on UserRole /
+        # NotificationType — SQLAlchemy otherwise persists the enum
+        # *name* ("PENDING") instead of its .value ("pending").
+        Enum(
+            RestoreStatus,
+            values_callable=lambda obj: [e.value for e in obj],
+            name="restore_status",
+        ),
+        nullable=False, default=RestoreStatus.PENDING, index=True,
+    )
+
+    # Reviewer details. NULL until review happens.
+    reviewed_by_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=True, index=True,
+    )
+    reviewed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    review_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Explicit foreign_keys — required when 2+ FKs point at the same
+    # table (user), else SQLAlchemy can't decide which side joins.
+    submitted_by: Mapped["User"] = relationship(  # noqa: F821
+        "User", foreign_keys=[submitted_by_id],
+    )
+    reviewed_by: Mapped["User | None"] = relationship(  # noqa: F821
+        "User", foreign_keys=[reviewed_by_id],
+    )
+    knowledge_item: Mapped["KnowledgeItem"] = relationship("KnowledgeItem")  # noqa: F821
+
+    def __repr__(self) -> str:
+        return (
+            f"<ArchiveRestoreRequest id={self.id} item={self.knowledge_item_id} "
+            f"status={self.status.value}>"
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "knowledge_item_id": self.knowledge_item_id,
+            "submitted_by_id": self.submitted_by_id,
+            "submitted_at": self.submitted_at.isoformat() if self.submitted_at else None,
+            "reason": self.reason,
+            "status": self.status.value,
+            "reviewed_by_id": self.reviewed_by_id,
+            "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "review_note": self.review_note,
+        }

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,6 +15,10 @@ class UserRole(str, PyEnum):
     ADMIN = "admin"
     EDITOR = "editor"
     VIEWER = "viewer"
+    # KM Ops — knowledge-management ops team. Can review archive restore
+    # requests, approve recoveries, etc. Lower privilege than ADMIN
+    # (which still owns config like archive rules), higher than EDITOR.
+    KM_OPS = "km_ops"
 
 
 class User(Base):

--- a/backend/app/routers/restore.py
+++ b/backend/app/routers/restore.py
@@ -1,0 +1,195 @@
+"""Archive-restore-request HTTP API (US-060/062).
+
+Endpoints:
+
+  POST   /api/v1/archive/restore-requests         submit a request
+  GET    /api/v1/archive/restore-requests         list
+                                                  - regular user: own only
+                                                  - km_ops/admin:  all (optional ?mine=1)
+                                                  - ?status=pending|approved|rejected
+  GET    /api/v1/archive/restore-requests/{id}    read one (own or reviewer)
+  POST   /api/v1/archive/restore-requests/{id}/approve  km_ops/admin
+  POST   /api/v1/archive/restore-requests/{id}/reject   km_ops/admin
+
+Router commits the transaction once per request. Service layer (see
+`services/restore.py`) only add/flushes, so we keep the "one commit per
+HTTP call" invariant the rest of the app uses.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.core.deps import CurrentUser, DB
+from app.models.knowledge import KnowledgeItem
+from app.models.restore import ArchiveRestoreRequest, RestoreStatus
+from app.models.user import User, UserRole
+from app.services.restore import (
+    REVIEWER_ROLES,
+    RestoreError,
+    approve_request,
+    reject_request,
+    submit_request,
+)
+
+router = APIRouter(
+    prefix="/api/v1/archive/restore-requests",
+    tags=["archive-restore"],
+)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────
+
+class SubmitIn(BaseModel):
+    knowledge_item_id: int
+    reason: str | None = Field(default=None, max_length=2000)
+
+
+class ReviewIn(BaseModel):
+    """Body for approve and reject.
+
+    Note is optional on approve (nice-to-have) but in practice required
+    on reject — we don't enforce it server-side because "the note was
+    empty" feels like a lint, not a domain rule. Frontend can nag the
+    reviewer to fill it in.
+    """
+    note: str | None = Field(default=None, max_length=2000)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def _is_reviewer(user: User) -> bool:
+    return user.role in REVIEWER_ROLES
+
+
+def _raise(err: RestoreError) -> None:
+    raise HTTPException(
+        status_code=err.status_code,
+        detail={"code": err.code, "message": err.message},
+    )
+
+
+async def _load_req_with_item(
+    db, req_id: int,
+) -> tuple[ArchiveRestoreRequest, KnowledgeItem]:
+    """Fetch request + its item in two small queries (not a join — the
+    item is needed for both permission checks and the approve-side
+    un-archive mutation, so load the ORM object, not a row tuple)."""
+    req = (await db.execute(
+        select(ArchiveRestoreRequest).where(ArchiveRestoreRequest.id == req_id)
+    )).scalar_one_or_none()
+    if req is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="restore request not found",
+        )
+    item = (await db.execute(
+        select(KnowledgeItem).where(KnowledgeItem.id == req.knowledge_item_id)
+    )).scalar_one_or_none()
+    if item is None:
+        # Shouldn't happen — FK is CASCADE. Treat as 404.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="knowledge item missing",
+        )
+    return req, item
+
+
+# ── Routes ────────────────────────────────────────────────────────────
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def submit(body: SubmitIn, user: CurrentUser, db: DB) -> dict:
+    item = (await db.execute(
+        select(KnowledgeItem).where(KnowledgeItem.id == body.knowledge_item_id)
+    )).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="knowledge item not found",
+        )
+
+    try:
+        req = await submit_request(
+            db, submitter=user, item=item, reason=body.reason,
+        )
+    except RestoreError as e:
+        _raise(e)
+
+    await db.commit()
+    await db.refresh(req)
+    return req.to_dict()
+
+
+@router.get("")
+async def list_requests(
+    user: CurrentUser,
+    db: DB,
+    status_filter: RestoreStatus | None = Query(default=None, alias="status"),
+    mine: bool = Query(default=False, description="force-filter to own requests even for reviewers"),
+) -> list[dict]:
+    q = select(ArchiveRestoreRequest).order_by(
+        ArchiveRestoreRequest.submitted_at.desc()
+    )
+    # Non-reviewers can only see their own. `mine=1` is a convenience
+    # toggle for reviewers who want their own queue in the UI.
+    if not _is_reviewer(user) or mine:
+        q = q.where(ArchiveRestoreRequest.submitted_by_id == user.id)
+    if status_filter is not None:
+        q = q.where(ArchiveRestoreRequest.status == status_filter)
+
+    rows = (await db.execute(q)).scalars().all()
+    return [r.to_dict() for r in rows]
+
+
+@router.get("/{req_id}")
+async def read_one(req_id: int, user: CurrentUser, db: DB) -> dict:
+    req, _item = await _load_req_with_item(db, req_id)
+    if not _is_reviewer(user) and req.submitted_by_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="not your request",
+        )
+    return req.to_dict()
+
+
+@router.post("/{req_id}/approve")
+async def approve(
+    req_id: int, body: ReviewIn, user: CurrentUser, db: DB,
+) -> dict:
+    if not _is_reviewer(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="km_ops or admin only",
+        )
+    req, item = await _load_req_with_item(db, req_id)
+    try:
+        await approve_request(
+            db, req=req, item=item, reviewer=user, note=body.note,
+        )
+    except RestoreError as e:
+        _raise(e)
+    await db.commit()
+    await db.refresh(req)
+    return req.to_dict()
+
+
+@router.post("/{req_id}/reject")
+async def reject(
+    req_id: int, body: ReviewIn, user: CurrentUser, db: DB,
+) -> dict:
+    if not _is_reviewer(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="km_ops or admin only",
+        )
+    req, item = await _load_req_with_item(db, req_id)
+    try:
+        await reject_request(
+            db, req=req, item=item, reviewer=user, note=body.note,
+        )
+    except RestoreError as e:
+        _raise(e)
+    await db.commit()
+    await db.refresh(req)
+    return req.to_dict()

--- a/backend/app/services/restore.py
+++ b/backend/app/services/restore.py
@@ -1,0 +1,225 @@
+"""Archive-restore-request service layer.
+
+Glue between the router and the database + notification dispatch. The
+router owns the transaction boundary; helpers here only `db.add`/`flush`
+and leave the commit to the caller (same contract as `services/notify.py`).
+
+Three operations:
+
+  * submit_request — user asks for their archived doc back
+  * approve_request — KM Ops un-archives + notifies submitter
+  * reject_request — KM Ops notes a reason + notifies submitter
+
+All three fan out in-app notifications via `services/notify.dispatch`,
+which writes to the notifications table (durable) and pushes over WS if
+the recipient is online. Email nudges are intentionally *not* wired here
+yet — they land when #87's mailer is on main, at which point the worker
+already has a mailer reference and we can revisit.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.knowledge import KnowledgeItem
+from app.models.notification import NotificationType
+from app.models.restore import ArchiveRestoreRequest, RestoreStatus
+from app.models.user import User, UserRole
+from app.services.notify import dispatch
+
+
+# Roles allowed to review (approve/reject) a restore request.
+REVIEWER_ROLES: tuple[UserRole, ...] = (UserRole.ADMIN, UserRole.KM_OPS)
+
+
+class RestoreError(Exception):
+    """Domain error for restore-request flows.
+
+    Router maps to HTTP status via `.status_code`. Using a custom type
+    instead of raising HTTPException in the service keeps this module
+    framework-agnostic (unit tests don't need FastAPI).
+    """
+
+    def __init__(self, code: str, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+async def _load_reviewers(db: AsyncSession) -> list[User]:
+    """All active users with a reviewer role — the submit fan-out target."""
+    q = select(User).where(
+        User.is_active.is_(True),
+        User.role.in_(REVIEWER_ROLES),
+    )
+    return list((await db.execute(q)).scalars().all())
+
+
+async def submit_request(
+    db: AsyncSession,
+    *,
+    submitter: User,
+    item: KnowledgeItem,
+    reason: str | None,
+) -> ArchiveRestoreRequest:
+    """Create a PENDING request and notify all KM-Ops/Admin reviewers.
+
+    Preconditions enforced here (not in the router) so CLI / background
+    callers get the same safety:
+      - item must be archived
+      - at most one PENDING request per item (FIFO; next user must wait)
+    """
+    if not item.is_archived:
+        raise RestoreError(
+            "NOT_ARCHIVED",
+            "item is not archived; nothing to restore",
+            status_code=409,
+        )
+
+    # FIFO: block duplicate PENDING requests on the same item. This is a
+    # read-check-then-write — fine here because the request cadence is
+    # human-scale (no hot contention), and a duplicate is a harmless 409.
+    existing = await db.execute(
+        select(ArchiveRestoreRequest.id).where(
+            ArchiveRestoreRequest.knowledge_item_id == item.id,
+            ArchiveRestoreRequest.status == RestoreStatus.PENDING,
+        ).limit(1)
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise RestoreError(
+            "ALREADY_PENDING",
+            "a pending restore request already exists for this item",
+            status_code=409,
+        )
+
+    req = ArchiveRestoreRequest(
+        knowledge_item_id=item.id,
+        submitted_by_id=submitter.id,
+        reason=reason,
+        status=RestoreStatus.PENDING,
+    )
+    db.add(req)
+    await db.flush()  # populate req.id + req.submitted_at
+
+    # Fan out to all reviewers in-app. If zero reviewers exist the request
+    # just sits PENDING — an admin can still see it on list, and it's a
+    # config problem, not a data problem.
+    reviewers = await _load_reviewers(db)
+    payload = {
+        "request_id": req.id,
+        "knowledge_item_id": item.id,
+        "knowledge_item_name": item.name,
+        "submitter_id": submitter.id,
+        "submitter_name": submitter.display_name,
+        "reason": reason,
+    }
+    title = f"Restore request: {item.name}"
+    for r in reviewers:
+        await dispatch(
+            db,
+            user_id=r.id,
+            type=NotificationType.RESTORE_REQUEST_SUBMITTED,
+            payload=payload,
+            title=title,
+        )
+
+    return req
+
+
+async def _finalize_review(
+    db: AsyncSession,
+    *,
+    req: ArchiveRestoreRequest,
+    reviewer: User,
+    approve: bool,
+    note: str | None,
+) -> ArchiveRestoreRequest:
+    """Shared state transition for approve/reject.
+
+    Enforces: the request must currently be PENDING. Reviewed rows are
+    immutable by convention (no endpoint mutates them), so the audit
+    trail is the row itself.
+    """
+    if req.status != RestoreStatus.PENDING:
+        raise RestoreError(
+            "NOT_PENDING",
+            f"request is {req.status.value}; cannot change",
+            status_code=409,
+        )
+
+    req.status = RestoreStatus.APPROVED if approve else RestoreStatus.REJECTED
+    req.reviewed_by_id = reviewer.id
+    req.reviewed_at = datetime.now(timezone.utc)
+    req.review_note = note
+
+    return req
+
+
+async def approve_request(
+    db: AsyncSession,
+    *,
+    req: ArchiveRestoreRequest,
+    item: KnowledgeItem,
+    reviewer: User,
+    note: str | None,
+) -> ArchiveRestoreRequest:
+    """Approve: un-archive the item and notify the submitter."""
+    await _finalize_review(
+        db, req=req, reviewer=reviewer, approve=True, note=note,
+    )
+
+    # Un-archive. Clear archive_reminder_sent_at so the auto-archive
+    # window restarts from scratch — otherwise a restored doc that's
+    # still past `inactive_days` would be re-archived on the next tick.
+    item.is_archived = False
+    item.archived_at = None
+    item.archive_reminder_sent_at = None
+
+    await dispatch(
+        db,
+        user_id=req.submitted_by_id,
+        type=NotificationType.RESTORE_REQUEST_APPROVED,
+        payload={
+            "request_id": req.id,
+            "knowledge_item_id": item.id,
+            "knowledge_item_name": item.name,
+            "reviewer_id": reviewer.id,
+            "reviewer_name": reviewer.display_name,
+            "note": note,
+        },
+        title=f"Restore approved: {item.name}",
+    )
+    return req
+
+
+async def reject_request(
+    db: AsyncSession,
+    *,
+    req: ArchiveRestoreRequest,
+    item: KnowledgeItem,
+    reviewer: User,
+    note: str | None,
+) -> ArchiveRestoreRequest:
+    """Reject: record the reason and notify the submitter. Item stays archived."""
+    await _finalize_review(
+        db, req=req, reviewer=reviewer, approve=False, note=note,
+    )
+
+    await dispatch(
+        db,
+        user_id=req.submitted_by_id,
+        type=NotificationType.RESTORE_REQUEST_REJECTED,
+        payload={
+            "request_id": req.id,
+            "knowledge_item_id": item.id,
+            "knowledge_item_name": item.name,
+            "reviewer_id": reviewer.id,
+            "reviewer_name": reviewer.display_name,
+            "note": note,
+        },
+        title=f"Restore rejected: {item.name}",
+    )
+    return req


### PR DESCRIPTION
Closes #58.

## Summary

Users can request an archived knowledge item back; KM Ops (new role)
reviews and approves or rejects with a note. Notifications fan out
in-app on submit / approve / reject.

## Shape

- `UserRole.KM_OPS` — new reviewer role between EDITOR and ADMIN.
- `ArchiveRestoreRequest` (new table) with `RestoreStatus` enum
  (pending/approved/rejected). Reviewed rows are immutable by
  convention, so the row itself is the audit trail — no separate
  approval_logs table.
- 3 new `NotificationType` values: `restore_request_submitted` (to
  reviewers), `restore_request_approved`, `restore_request_rejected`
  (to submitter).

## Endpoints (`/api/v1/archive/restore-requests`)

| Method | Path | Who |
|---|---|---|
| POST | `/` | any authenticated user |
| GET | `/?status=&mine=` | own for regular users; all for reviewers |
| GET | `/{id}` | own or reviewer |
| POST | `/{id}/approve` | reviewers only |
| POST | `/{id}/reject` | reviewers only |

## Service invariants

- Submit requires `item.is_archived=True`.
- At most one PENDING request per item (FIFO).
- On approve: `is_archived=False`, `archived_at=NULL`,
  `archive_reminder_sent_at=NULL` — otherwise a restored-but-still-stale
  doc would be re-archived on the next tick.

## Migration

`0008_restore_requests.py`:
- `ALTER TYPE ... ADD VALUE IF NOT EXISTS` (after `COMMIT`) for
  `userrole.km_ops` + 3 `notification_type` values.
- `CREATE TYPE restore_status`.
- `CREATE TABLE archive_restore_requests` + 4 indexes.

**Parallel-revision note:** #87 also declares `revision=\"0008\"`.
Same \"loser rebases\" pattern we ran on #86/#87 — whichever lands
first keeps the slot.

## Design gotchas

Honored all three flagged in Zoey's email:
- `values_callable` on `RestoreStatus` (persists lowercase values, not
  ALLCAPS names).
- `foreign_keys=[...]` on both `submitted_by` and `reviewed_by`
  relationships (two FKs to `users` → SQLAlchemy can't guess).
- `ondelete=RESTRICT` on submitter + reviewer FKs so the audit trail
  is never silently orphaned.

## Not included

Email nudges — the mailer module lands with #87. In-app notifications
are authoritative and durable (backfilled via #27's WS reconnect
flush); email is a best-effort add-on that'll wire up cleanly once
#87 is on main.

## Test plan

- [ ] Bring the compose stack up and `alembic upgrade head` — migration
      should apply cleanly on top of main.
- [ ] Archive an item, submit a restore request as the uploader.
- [ ] Verify all admin + km_ops users get an in-app notification.
- [ ] Approve as km_ops — item un-archives, submitter gets approval
      notification.
- [ ] Submit on a non-archived item → 409 `NOT_ARCHIVED`.
- [ ] Submit twice on the same archived item → second gets 409
      `ALREADY_PENDING`.
- [ ] Non-reviewer attempts approve → 403.
- [ ] Approve on an already-reviewed request → 409 `NOT_PENDING`.