### PR TITLE
feat: #59 batch ops with per-item RBAC + partial-success

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.routers import graph as graph_router
 from app.routers import notifications
 from app.routers import archive as archive_router
 from app.routers import restore as restore_router
+from app.routers import batch as batch_router
 
 
 @asynccontextmanager
@@ -98,6 +99,7 @@ app.include_router(graph_router.router)
 app.include_router(notifications.router)
 app.include_router(archive_router.router)
 app.include_router(restore_router.router)
+app.include_router(batch_router.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])

--- a/backend/app/models/sharing.py
+++ b/backend/app/models/sharing.py
@@ -33,7 +33,11 @@ class SharingRecord(Base):
     shared_by_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     shared_to_user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True)
     shared_to_department: Mapped[str | None] = mapped_column(String(100), nullable=True)  # dept-level share
-    permission: Mapped[SharePermission] = mapped_column(Enum(SharePermission), default=SharePermission.VIEW, nullable=False)
+    permission: Mapped[SharePermission] = mapped_column(
+        Enum(SharePermission, values_callable=lambda obj: [e.value for e in obj]),
+        default=SharePermission.VIEW,
+        nullable=False,
+    )
     token: Mapped[str | None] = mapped_column(String(255), unique=True, index=True, nullable=True)  # public link token
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -54,7 +58,11 @@ class AuditLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     actor_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    action: Mapped[AuditAction] = mapped_column(Enum(AuditAction), nullable=False, index=True)
+    action: Mapped[AuditAction] = mapped_column(
+        Enum(AuditAction, values_callable=lambda obj: [e.value for e in obj]),
+        nullable=False,
+        index=True,
+    )
     resource_type: Mapped[str | None] = mapped_column(String(100), nullable=True)  # "knowledge_item", "user", etc.
     resource_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     detail: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/backend/app/routers/batch.py
+++ b/backend/app/routers/batch.py
@@ -1,0 +1,90 @@
+"""Batch operations on knowledge items (US-055).
+
+Three endpoints, all under `/api/v1/knowledge/batch`:
+
+  POST /batch/move     move N items to a category (or out of any)
+  POST /batch/delete   hard-delete N items
+  POST /batch/share    share N items with the same target + permission
+
+All three return HTTP 207 Multi-Status with a {succeeded, failed, batch_id}
+body. Why 207 even on "all succeeded":
+
+  - Clients parse one shape in one branch, not two shapes across 200/207.
+  - 207 is semantically honest: every batch endpoint *could* have partial
+    success, even if this particular call didn't.
+  - Mirrors the existing `/files/upload/batch` contract — one less thing
+    for the frontend to special-case.
+
+Per-item RBAC lives in services/batch_ops.py. The router just maps
+request → service call → response.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from app.core.deps import CurrentUser, DB
+from app.schemas.batch import (
+    BatchDeleteRequest,
+    BatchMoveRequest,
+    BatchResponse,
+    BatchShareRequest,
+)
+from app.services import batch_ops
+
+router = APIRouter(
+    prefix="/api/v1/knowledge/batch",
+    tags=["knowledge-batch"],
+)
+
+
+@router.post(
+    "/move",
+    response_model=BatchResponse,
+    status_code=status.HTTP_207_MULTI_STATUS,
+    summary="批量移动知识条目到目标分类",
+)
+async def batch_move(
+    body: BatchMoveRequest, user: CurrentUser, db: DB,
+) -> dict:
+    result = await batch_ops.batch_move(
+        db, user=user, ids=body.ids, category_id=body.category_id,
+    )
+    await db.commit()
+    return result
+
+
+@router.post(
+    "/delete",
+    response_model=BatchResponse,
+    status_code=status.HTTP_207_MULTI_STATUS,
+    summary="批量删除知识条目（硬删除，需为拥有者或管理员）",
+)
+async def batch_delete(
+    body: BatchDeleteRequest, user: CurrentUser, db: DB,
+) -> dict:
+    result = await batch_ops.batch_delete(db, user=user, ids=body.ids)
+    await db.commit()
+    return result
+
+
+@router.post(
+    "/share",
+    response_model=BatchResponse,
+    status_code=status.HTTP_207_MULTI_STATUS,
+    summary="批量分享知识条目到同一目标（需为拥有者或管理员）",
+)
+async def batch_share(
+    body: BatchShareRequest, user: CurrentUser, db: DB,
+) -> dict:
+    result = await batch_ops.batch_share(
+        db,
+        user=user,
+        ids=body.ids,
+        target=body.target,
+        permission=body.permission,
+        target_user_id=body.target_user_id,
+        target_department=body.target_department,
+        expires_hours=body.expires_hours,
+    )
+    await db.commit()
+    return result

--- a/backend/app/schemas/batch.py
+++ b/backend/app/schemas/batch.py
@@ -1,0 +1,63 @@
+"""Request + response shapes for batch knowledge-item operations."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.schemas.sharing import PermissionLevel, ShareTarget
+
+
+# Upper bound per call. Above this the client should paginate — mostly
+# to keep a single 207 response and its audit rows under a reasonable
+# size. Picked 500 as a round number; tune later if needed.
+MAX_BATCH_SIZE = 500
+
+
+class _BaseBatchIn(BaseModel):
+    ids: list[int] = Field(min_length=1, max_length=MAX_BATCH_SIZE)
+
+
+class BatchMoveRequest(_BaseBatchIn):
+    category_id: int | None = Field(
+        default=None,
+        description="Destination category. null moves items out of any category.",
+    )
+
+
+class BatchDeleteRequest(_BaseBatchIn):
+    pass
+
+
+class BatchShareRequest(_BaseBatchIn):
+    target: ShareTarget
+    permission: PermissionLevel = PermissionLevel.VIEW
+    target_user_id: int | None = None
+    target_department: str | None = None
+    expires_hours: int | None = 72
+
+    @model_validator(mode="after")
+    def _check_target_fields(self):
+        # Mirrors CreateShareRequest — we validate up front so a bad
+        # request doesn't get halfway through the loop before failing.
+        if self.target == ShareTarget.USER and not self.target_user_id:
+            raise ValueError("target_user_id required when target=user")
+        if self.target == ShareTarget.DEPARTMENT and not self.target_department:
+            raise ValueError("target_department required when target=department")
+        return self
+
+
+class FailedItem(BaseModel):
+    id: int
+    reason: str
+
+
+class BatchResponse(BaseModel):
+    """Response body for all three batch endpoints.
+
+    Returned with HTTP 207 Multi-Status regardless of whether any item
+    actually failed — the caller's treatment shouldn't flip between 200
+    and 207 based on run-time data, because frontends would end up
+    parsing one shape in two branches.
+    """
+    batch_id: str
+    succeeded: list[dict]   # op-specific; see services/batch_ops.py
+    failed: list[FailedItem]

--- a/backend/app/services/batch_ops.py
+++ b/backend/app/services/batch_ops.py
@@ -1,0 +1,365 @@
+"""Batch operations on knowledge items — move / delete / share (US-055).
+
+One function per op, all sharing the same contract:
+
+    async def batch_X(db, *, user, ids, op_payload) -> BatchResult
+
+`BatchResult` is a plain dict with `{succeeded: [...], failed: [...]}`.
+Each failed item carries a short `reason` code the frontend can map to
+copy. The router translates this into a 207 Multi-Status body.
+
+Design choices:
+
+1. Per-item isolation. A permission miss or "not found" on item 3 must
+   not abort items 4..N. We wrap each item's DB mutation in a SAVEPOINT
+   (`async with db.begin_nested()`) so a flush failure — e.g. an FK
+   violation, a deadlock, a stale reference — rolls back only that
+   item's changes and leaves the outer transaction healthy for the
+   next iteration. Without the savepoint, any flush error would
+   poison the async session and silently fail every subsequent item
+   as R_UNEXPECTED.
+
+2. Single outer transaction. We flush per-item inside savepoints but
+   commit once at the router level. If any unexpected exception
+   escapes the loop, the router's exception handler rolls back the
+   whole batch — better than a half-applied move.
+
+3. RBAC reuse. We lean on `services/sharing.check_user_access` for
+   move/share, and a small `_can_manage` helper for delete/share (which
+   require ownership, not just EDIT access). No new permission model.
+
+4. Audit log. One `AuditLog` row per item per batch, grouped by a
+   `batch_id` (UUID hex) we emit in `detail`. That lets ops query
+   "show me all outcomes for batch X" without a separate table —
+   consistent with #58's "the row is the audit log" principle.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Iterable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.knowledge import Category, KnowledgeItem
+from app.models.sharing import AuditAction, AuditLog, SharePermission
+from app.models.user import User, UserRole
+from app.schemas.sharing import CreateShareRequest, PermissionLevel, ShareTarget
+from app.services.sharing import check_user_access, create_share
+
+log = logging.getLogger(__name__)
+
+
+# ── Result shape ──────────────────────────────────────────────────────
+
+SuccessItem = dict[str, Any]   # {id: int, ...optional op-specific fields}
+FailureItem = dict[str, Any]   # {id: int, reason: str}
+BatchResult = dict[str, Any]   # {succeeded: [...], failed: [...], batch_id: str}
+
+
+# ── Reason codes ──────────────────────────────────────────────────────
+# Short stable strings. Frontend maps to copy; tests assert on these.
+
+R_NOT_FOUND         = "NOT_FOUND"
+R_PERMISSION_DENIED = "PERMISSION_DENIED"
+R_INVALID_TARGET    = "INVALID_TARGET"   # move: category_id doesn't exist
+R_ALREADY_DELETED   = "ALREADY_DELETED"  # paranoia; cascaded deletes shouldn't surface this
+R_UNEXPECTED        = "UNEXPECTED"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def _can_manage(item: KnowledgeItem, user: User) -> bool:
+    """Owner-or-admin gate. Used by delete and share (EDIT-shared users
+    should not be able to delete someone else's doc or re-share it)."""
+    return user.role == UserRole.ADMIN or item.uploader_id == user.id
+
+
+def _new_batch_id() -> str:
+    # 32-hex chars; compact enough to index + grep, random enough to
+    # group rows without collisions across concurrent batches.
+    return uuid.uuid4().hex
+
+
+async def _load_items(
+    db: AsyncSession, ids: Iterable[int],
+) -> dict[int, KnowledgeItem]:
+    """Fetch the items once up front. Returns id → item; missing ids are
+    absent from the dict (caller reports NOT_FOUND for them)."""
+    ids = list(ids)
+    if not ids:
+        return {}
+    q = select(KnowledgeItem).where(KnowledgeItem.id.in_(ids))
+    rows = (await db.execute(q)).scalars().all()
+    return {i.id: i for i in rows}
+
+
+def _log_result(
+    db: AsyncSession,
+    *,
+    batch_id: str,
+    action: AuditAction,
+    actor: User,
+    item_id: int,
+    success: bool,
+    reason: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Append one audit row for this item's outcome in the batch."""
+    detail: dict[str, Any] = {
+        "batch_id": batch_id,
+        "result": "succeeded" if success else "failed",
+    }
+    if reason:
+        detail["reason"] = reason
+    if extra:
+        detail.update(extra)
+    db.add(AuditLog(
+        actor_id=actor.id,
+        action=action,
+        resource_type="knowledge_item",
+        resource_id=item_id,
+        detail=detail,
+    ))
+
+
+# ── Operations ────────────────────────────────────────────────────────
+
+async def batch_move(
+    db: AsyncSession,
+    *,
+    user: User,
+    ids: list[int],
+    category_id: int | None,
+) -> BatchResult:
+    """Move each item to `category_id` (or out of any category if None).
+
+    Permission: EDIT on the item. Owner + admin always qualify (owner
+    via check_user_access's fallback, admin via the explicit bypass
+    below). Rationale: moving between categories is an edit-level
+    action, not an ownership-level one — that matches how other
+    shared-editor tools behave.
+    """
+    batch_id = _new_batch_id()
+    succeeded: list[SuccessItem] = []
+    failed: list[FailureItem] = []
+
+    # Validate target category once, not N times.
+    if category_id is not None:
+        cat = (await db.execute(
+            select(Category).where(Category.id == category_id)
+        )).scalar_one_or_none()
+        if cat is None:
+            # Degenerate case — every item will fail for the same reason,
+            # so short-circuit with INVALID_TARGET on the whole batch
+            # rather than writing N audit rows.
+            for item_id in ids:
+                failed.append({"id": item_id, "reason": R_INVALID_TARGET})
+            return {
+                "batch_id": batch_id,
+                "succeeded": succeeded,
+                "failed": failed,
+            }
+
+    items = await _load_items(db, ids)
+
+    for item_id in ids:
+        item = items.get(item_id)
+        if item is None:
+            failed.append({"id": item_id, "reason": R_NOT_FOUND})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.UPDATE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_NOT_FOUND,
+            )
+            continue
+
+        allowed = (
+            user.role == UserRole.ADMIN
+            or await check_user_access(
+                db, item.id, user, required=SharePermission.EDIT,
+            )
+        )
+        if not allowed:
+            failed.append({"id": item_id, "reason": R_PERMISSION_DENIED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.UPDATE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_PERMISSION_DENIED,
+            )
+            continue
+
+        old_cat = item.category_id
+        try:
+            # SAVEPOINT per item — flush failures (FK violations etc.)
+            # roll back only this item's change, not the whole batch.
+            async with db.begin_nested():
+                item.category_id = category_id
+                await db.flush()
+        except Exception as exc:  # noqa: BLE001
+            log.exception("batch_move failed on item=%s: %s", item_id, exc)
+            failed.append({"id": item_id, "reason": R_UNEXPECTED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.UPDATE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_UNEXPECTED,
+            )
+            continue
+
+        succeeded.append({"id": item_id, "category_id": category_id})
+        _log_result(
+            db, batch_id=batch_id, action=AuditAction.UPDATE,
+            actor=user, item_id=item_id, success=True,
+            extra={"from_category_id": old_cat, "to_category_id": category_id},
+        )
+
+    return {"batch_id": batch_id, "succeeded": succeeded, "failed": failed}
+
+
+async def batch_delete(
+    db: AsyncSession,
+    *,
+    user: User,
+    ids: list[int],
+) -> BatchResult:
+    """Hard-delete each item.
+
+    Permission: owner-or-admin. EDIT-shared users can modify but not
+    destroy — delete is the one action where shared access is not
+    enough. Matches how Google Drive, Notion, etc. handle this.
+
+    Cascades (tag_assignments, sharing_records) fire automatically via
+    the relationship definitions on KnowledgeItem.
+    """
+    batch_id = _new_batch_id()
+    succeeded: list[SuccessItem] = []
+    failed: list[FailureItem] = []
+
+    items = await _load_items(db, ids)
+
+    for item_id in ids:
+        item = items.get(item_id)
+        if item is None:
+            failed.append({"id": item_id, "reason": R_NOT_FOUND})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.DELETE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_NOT_FOUND,
+            )
+            continue
+
+        if not _can_manage(item, user):
+            failed.append({"id": item_id, "reason": R_PERMISSION_DENIED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.DELETE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_PERMISSION_DENIED,
+            )
+            continue
+
+        # Snapshot metadata outside the savepoint — if the delete rolls
+        # back, we still want the snapshot for the audit row on failure
+        # paths, and on success we've already captured what we need.
+        snapshot = {"name": item.name, "uploader_id": item.uploader_id}
+        try:
+            async with db.begin_nested():
+                await db.delete(item)
+                await db.flush()
+        except Exception as exc:  # noqa: BLE001
+            log.exception("batch_delete failed on item=%s: %s", item_id, exc)
+            failed.append({"id": item_id, "reason": R_UNEXPECTED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.DELETE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_UNEXPECTED,
+            )
+            continue
+
+        succeeded.append({"id": item_id})
+        _log_result(
+            db, batch_id=batch_id, action=AuditAction.DELETE,
+            actor=user, item_id=item_id, success=True,
+            extra=snapshot,
+        )
+
+    return {"batch_id": batch_id, "succeeded": succeeded, "failed": failed}
+
+
+async def batch_share(
+    db: AsyncSession,
+    *,
+    user: User,
+    ids: list[int],
+    target: ShareTarget,
+    permission: PermissionLevel,
+    target_user_id: int | None,
+    target_department: str | None,
+    expires_hours: int | None,
+) -> BatchResult:
+    """Share each item with the same target + permission.
+
+    Permission: owner-or-admin. You can't re-share what you don't own —
+    transitive sharing would punch holes in the RBAC model we just built.
+
+    Per-item outcome carries the new `share_id` so the frontend can link
+    to each created share record in one round trip.
+    """
+    batch_id = _new_batch_id()
+    succeeded: list[SuccessItem] = []
+    failed: list[FailureItem] = []
+
+    items = await _load_items(db, ids)
+
+    for item_id in ids:
+        item = items.get(item_id)
+        if item is None:
+            failed.append({"id": item_id, "reason": R_NOT_FOUND})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.SHARE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_NOT_FOUND,
+            )
+            continue
+
+        if not _can_manage(item, user):
+            failed.append({"id": item_id, "reason": R_PERMISSION_DENIED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.SHARE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_PERMISSION_DENIED,
+            )
+            continue
+
+        try:
+            req = CreateShareRequest(
+                knowledge_item_id=item_id,
+                target=target,
+                permission=permission,
+                target_user_id=target_user_id,
+                target_department=target_department,
+                expires_hours=expires_hours,
+            )
+            async with db.begin_nested():
+                # create_share flushes internally; savepoint catches
+                # uniqueness / FK failures without breaking the batch.
+                record = await create_share(db, req, shared_by=user)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("batch_share failed on item=%s: %s", item_id, exc)
+            failed.append({"id": item_id, "reason": R_UNEXPECTED})
+            _log_result(
+                db, batch_id=batch_id, action=AuditAction.SHARE,
+                actor=user, item_id=item_id, success=False,
+                reason=R_UNEXPECTED,
+            )
+            continue
+
+        succeeded.append({"id": item_id, "share_id": record.id})
+        _log_result(
+            db, batch_id=batch_id, action=AuditAction.SHARE,
+            actor=user, item_id=item_id, success=True,
+            extra={"share_id": record.id, "target": target.value,
+                   "permission": permission.value},
+        )
+
+    return {"batch_id": batch_id, "succeeded": succeeded, "failed": failed}


### PR DESCRIPTION
Closes #59.

## Summary

Adds `/api/v1/knowledge/batch/{move,delete,share}`. Each item is
permission-checked independently; items that fail RBAC (or don't exist)
are reported in the response without aborting the rest of the batch.

## Response shape (HTTP 207 Multi-Status)

```json
{
  "batch_id": "f4a1...hex",
  "succeeded": [{"id": 1}, {"id": 2, "share_id": 42}],
  "failed": [
    {"id": 3, "reason": "PERMISSION_DENIED"},
    {"id": 4, "reason": "NOT_FOUND"}
  ]
}
```

**Why 207 unconditionally** (not 200 vs 207 based on run-time data):
frontend parses one shape in one branch; 207 is semantically honest for
an endpoint that *could* have partial failure; matches the existing
`/files/upload/batch` contract.

Stable reason codes: `NOT_FOUND`, `PERMISSION_DENIED`, `INVALID_TARGET`
(move target category missing — short-circuits whole batch),
`UNEXPECTED` (caught by per-item guard, logged loudly).

## Permission model

| op | required |
|---|---|
| move | `EDIT` on item OR owner OR admin |
| delete | owner OR admin only |
| share | owner OR admin only |

Rationale: delete is destructive and share is transitive — both would
punch holes in the RBAC model if EDIT-shared users could do them.
Moving between categories is edit-level, consistent with how other
shared-editor tools work. Reuses `services/sharing.check_user_access`;
no new permission model.

## Layering

- `schemas/batch.py` — request/response shapes; `MAX_BATCH_SIZE=500`.
- `services/batch_ops.py` — per-op helpers with the loop, per-item RBAC
  check, audit-log row per outcome. Framework-agnostic.
- `routers/batch.py` — thin wrapper; one `db.commit()` per HTTP call.

## Audit log (per Zoey's \"参考 #58 审批日志的设计\")

Reuses existing `AuditLog` — one row per item per batch, action in
{UPDATE, DELETE, SHARE}. `detail` carries:
- `batch_id` (UUID hex, shared across all rows in one batch)
- `result` (\"succeeded\" | \"failed\")
- `reason` (on failure, same stable code the client sees)
- op-specific extras

Same \"the row *is* the audit log\" principle as #58's
`archive_restore_requests`. Ops can query outcomes by batch without a
separate table.

## Per-item isolation

Each item is wrapped in `try/except` so a stray FK violation on item 3
doesn't nuke items 4..N. Unexpected exceptions are logged and surface
as `UNEXPECTED` in the response. Router commits once at the end; if
anything escapes, FastAPI's handler 500s and SQLAlchemy auto-rolls the
whole batch — better than a half-applied move.

## Test plan

- [ ] `POST /move` with a mix of owned / EDIT-shared / no-access / bad
      ids → succeeded covers the first two, failed covers the rest with
      correct reasons.
- [ ] `POST /move` with `category_id` pointing at a non-existent
      category → entire batch fails with `INVALID_TARGET` (no per-item
      processing, no audit rows).
- [ ] `POST /delete` as an EDIT-shared user on someone else's item →
      `PERMISSION_DENIED` (even though they could *edit* it).
- [ ] `POST /delete` as admin on any item → success.
- [ ] `POST /share` creates N share records when owner; fails
      `PERMISSION_DENIED` for non-owners.
- [ ] Verify `AuditLog` rows exist for every succeeded and failed item,
      tagged with the same `batch_id` and action correct to the op.
- [ ] Batch of > 500 → 422 from Pydantic.