### PR TITLE
feat: #42 统一全文索引库 + #90 AI 助手 Enter 键 IME 修复

### DIFF
--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -22,8 +22,37 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
+import logging
+
 from app.core.deps import CurrentUser, DB
 from app.models.knowledge import Category
+from app.services.es_client import es
+
+
+_log = logging.getLogger(__name__)
+
+
+async def _es_index_category(c: Category) -> None:
+    """Mirror a Category into ekm_tags (kind=category) for unified search."""
+    try:
+        await es.index_tag(tag_id=c.id, body={
+            "id": c.id,
+            "kind": "category",
+            "name": c.name,
+            "description": c.description,
+            "slug": c.slug,
+            "color": None,
+            "usage_count": 0,
+        })
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES index_category failed id=%s: %s", c.id, exc)
+
+
+async def _es_delete_category(cat_id: int) -> None:
+    try:
+        await es.delete_tag(tag_id=cat_id, kind="category")
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES delete_category failed id=%s: %s", cat_id, exc)
 
 
 router = APIRouter(prefix="/api/v1/categories", tags=["categories"])
@@ -144,6 +173,7 @@ async def create_category(
         await db.rollback()
         raise HTTPException(status_code=409, detail="slug already exists")
     await db.refresh(cat)
+    await _es_index_category(cat)
     return _to_dict(cat)
 
 
@@ -183,6 +213,7 @@ async def update_category(
         await db.rollback()
         raise HTTPException(status_code=409, detail="slug already exists")
     await db.refresh(cat)
+    await _es_index_category(cat)
     return _to_dict(cat)
 
 
@@ -205,4 +236,5 @@ async def delete_category(cat_id: int, db: DB, user: CurrentUser):
     )
     await db.delete(cat)
     await db.commit()
+    await _es_delete_category(cat_id)
     return None

--- a/backend/app/routers/community.py
+++ b/backend/app/routers/community.py
@@ -24,11 +24,52 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
+import logging
+
 from app.core.deps import CurrentUser, DB
 from app.models.community import Post, Reply, ReplyLike
 from app.models.notification import NotificationType
 from app.models.user import User, UserRole
+from app.services.es_client import es
 from app.services.notify import dispatch as notify_dispatch
+
+
+_log = logging.getLogger(__name__)
+
+
+async def _es_index_post(p: Post) -> None:
+    """Mirror a Post into ekm_posts for unified search (#42).
+
+    Degradable: failures are logged and swallowed — the post is already
+    persisted in Postgres, which is authoritative. A follow-up reindex
+    job can heal missed updates.
+    """
+    try:
+        await es.index_post(post_id=p.id, body={
+            "id": p.id,
+            "title": p.title,
+            "body": p.body,
+            "author_id": p.author_id,
+            "reply_count": p.reply_count,
+            "created_at": p.created_at.isoformat() if p.created_at else None,
+        })
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES index_post failed id=%s: %s", p.id, exc)
+
+
+async def _es_index_reply(r: Reply) -> None:
+    try:
+        await es.index_reply(reply_id=r.id, body={
+            "id": r.id,
+            "post_id": r.post_id,
+            "parent_reply_id": r.parent_reply_id,
+            "content": "" if r.deleted_at else r.content,
+            "author_id": r.author_id,
+            "is_deleted": r.deleted_at is not None,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        })
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES index_reply failed id=%s: %s", r.id, exc)
 
 
 # @username mentions — allow word chars including CJK. Stop at whitespace
@@ -137,6 +178,9 @@ async def create_post(payload: PostCreate, db: DB, user: CurrentUser):
     db.add(p)
     await db.commit()
     await db.refresh(p)
+    # Two-phase: commit first, then index. If ES is down the post is still
+    # visible via the normal API; only unified search is temporarily stale.
+    await _es_index_post(p)
     return _post_dict(p)
 
 
@@ -274,6 +318,10 @@ async def create_reply(
 
     await db.commit()
     await db.refresh(r)
+    # Post-commit indexing (#42). Also refresh the parent post so
+    # reply_count in ES stays in sync with the denormalised counter.
+    await _es_index_reply(r)
+    await _es_index_post(post)
     return _reply_dict(r)
 
 
@@ -294,6 +342,11 @@ async def delete_reply(reply_id: int, db: DB, user: CurrentUser):
     if post is not None:
         post.reply_count = max((post.reply_count or 0) - 1, 0)
     await db.commit()
+    # Re-index the reply (is_deleted=True blanks it in search) and refresh
+    # the post's reply_count mirror.
+    await _es_index_reply(r)
+    if post is not None:
+        await _es_index_post(post)
     return None
 
 

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,10 +1,11 @@
 """Search API — Elasticsearch-backed full-text search.
 
-Two endpoints:
+Endpoints:
+    GET /api/v1/search         — unified cross-type search (#42 / US-075)
     GET /api/v1/search/items   — file/document list search (name + description)
     GET /api/v1/search/chunks  — passage-level search for RAG citations
 
-Both honor the IK analyzer configured in es_client.py, so Chinese queries
+All honor the IK analyzer configured in es_client.py, so Chinese queries
 tokenize correctly.
 """
 from __future__ import annotations
@@ -13,9 +14,44 @@ from fastapi import APIRouter, Query
 
 from app.core.deps import CurrentUser
 from app.services.es_client import es
+from app.services.search_aggregator import search_all
 
 
 router = APIRouter(prefix="/api/v1/search", tags=["search"])
+
+
+@router.get("")
+async def unified_search(
+    user: CurrentUser,
+    q: str = Query(..., min_length=1, description="search query"),
+    types: str | None = Query(
+        None,
+        description=(
+            "Comma-separated content types to search across. "
+            "Supported: documents, posts, tags. Default: all three."
+        ),
+    ),
+    size: int = Query(20, ge=1, le=100, description="per-bucket hit cap"),
+):
+    """Unified full-text search over documents, posts+replies, and tags+categories.
+
+    Returns grouped results:
+
+        {
+          "query": "关键词",
+          "total": 42,
+          "results": {
+            "documents": { "total": 12, "hits": [...] },
+            "posts":     { "total": 20, "hits": [...] },
+            "tags":      { "total": 10, "hits": [...] }
+          }
+        }
+
+    Per-bucket failures (e.g. a missing index) are logged and degraded to
+    an empty bucket rather than a 500 — a partial result beats no result.
+    """
+    requested = [t for t in (types or "").split(",") if t.strip()] or None
+    return await search_all(q, types=requested, size=size)
 
 
 @router.get("/items")

--- a/backend/app/routers/tags.py
+++ b/backend/app/routers/tags.py
@@ -23,8 +23,37 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
+import logging
+
 from app.core.deps import CurrentUser, DB
 from app.models.knowledge import KnowledgeItem, Tag, TagAssignment
+from app.services.es_client import es
+
+
+_log = logging.getLogger(__name__)
+
+
+async def _es_index_tag(t: Tag) -> None:
+    """Mirror a Tag into ekm_tags for unified search (#42). Best-effort."""
+    try:
+        await es.index_tag(tag_id=t.id, body={
+            "id": t.id,
+            "kind": "tag",
+            "name": t.name,
+            "description": None,
+            "slug": None,
+            "color": t.color,
+            "usage_count": t.usage_count,
+        })
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES index_tag failed id=%s: %s", t.id, exc)
+
+
+async def _es_delete_tag(tag_id: int) -> None:
+    try:
+        await es.delete_tag(tag_id=tag_id, kind="tag")
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("ES delete_tag failed id=%s: %s", tag_id, exc)
 
 
 router = APIRouter(prefix="/api/v1", tags=["tags"])
@@ -89,6 +118,7 @@ async def create_tag(payload: TagCreate, db: DB, user: CurrentUser):
         await db.rollback()
         raise HTTPException(status_code=409, detail="tag name already exists")
     await db.refresh(tag)
+    await _es_index_tag(tag)
     return _tag_dict(tag)
 
 
@@ -110,6 +140,7 @@ async def update_tag(
         await db.rollback()
         raise HTTPException(status_code=409, detail="tag name already exists")
     await db.refresh(tag)
+    await _es_index_tag(tag)
     return _tag_dict(tag)
 
 
@@ -123,6 +154,7 @@ async def delete_tag(tag_id: int, db: DB, user: CurrentUser):
     # CASCADE on tag_assignments.tag_id cleans up assignments automatically.
     await db.delete(tag)
     await db.commit()
+    await _es_delete_tag(tag_id)
     return None
 
 

--- a/backend/app/services/es_client.py
+++ b/backend/app/services/es_client.py
@@ -25,6 +25,12 @@ log = logging.getLogger(__name__)
 
 INDEX_CHUNKS = "ekm_chunks"
 INDEX_ITEMS = "ekm_items"
+# Unified full-text search (#42 / US-075). Three additional indices that
+# back the cross-type search endpoint. Mappings share the same IK-or-standard
+# analyzer detection as ekm_items so CJK queries tokenize consistently.
+INDEX_POSTS = "ekm_posts"
+INDEX_REPLIES = "ekm_replies"
+INDEX_TAGS = "ekm_tags"
 
 
 # Default to IK; if the plugin isn't installed, falls back to `standard`.
@@ -88,6 +94,77 @@ def _item_mapping(cjk_analyzer_index: str, cjk_analyzer_search: str) -> dict[str
     return base
 
 
+def _post_mapping(cjk_analyzer_index: str, cjk_analyzer_search: str) -> dict[str, Any]:
+    """Index one doc per Post. Replies live in their own index (see below)."""
+    base = _chunk_mapping(cjk_analyzer_index, cjk_analyzer_search)
+    base["mappings"]["properties"] = {
+        "id": {"type": "long"},
+        "title": {
+            "type": "text",
+            "analyzer": "ekm_cjk_index",
+            "search_analyzer": "ekm_cjk_search",
+            "fields": {"keyword": {"type": "keyword"}},
+        },
+        "body": {
+            "type": "text",
+            "analyzer": "ekm_cjk_index",
+            "search_analyzer": "ekm_cjk_search",
+        },
+        "author_id": {"type": "long"},
+        "reply_count": {"type": "integer"},
+        "created_at": {"type": "date"},
+    }
+    return base
+
+
+def _reply_mapping(cjk_analyzer_index: str, cjk_analyzer_search: str) -> dict[str, Any]:
+    """One doc per Reply. Separate index keeps post mapping small and lets
+    the unified-search UI show *which reply* matched (not just the post)."""
+    base = _chunk_mapping(cjk_analyzer_index, cjk_analyzer_search)
+    base["mappings"]["properties"] = {
+        "id": {"type": "long"},
+        "post_id": {"type": "long"},
+        "parent_reply_id": {"type": "long"},
+        "content": {
+            "type": "text",
+            "analyzer": "ekm_cjk_index",
+            "search_analyzer": "ekm_cjk_search",
+        },
+        "author_id": {"type": "long"},
+        "is_deleted": {"type": "boolean"},
+        "created_at": {"type": "date"},
+    }
+    return base
+
+
+def _tag_mapping(cjk_analyzer_index: str, cjk_analyzer_search: str) -> dict[str, Any]:
+    """Shared mapping for Tags and Categories, discriminated by `kind`.
+
+    Merging them keeps the unified-search aggregation flat (one ES query,
+    one result bucket) — the UI distinguishes them via the `kind` field if
+    it cares."""
+    base = _chunk_mapping(cjk_analyzer_index, cjk_analyzer_search)
+    base["mappings"]["properties"] = {
+        "id": {"type": "long"},
+        "kind": {"type": "keyword"},  # "tag" | "category"
+        "name": {
+            "type": "text",
+            "analyzer": "ekm_cjk_index",
+            "search_analyzer": "ekm_cjk_search",
+            "fields": {"keyword": {"type": "keyword"}},
+        },
+        "description": {
+            "type": "text",
+            "analyzer": "ekm_cjk_index",
+            "search_analyzer": "ekm_cjk_search",
+        },
+        "slug": {"type": "keyword"},
+        "color": {"type": "keyword"},
+        "usage_count": {"type": "integer"},
+    }
+    return base
+
+
 class ESClient:
     def __init__(self, url: str | None = None):
         self.url = url or settings.ELASTICSEARCH_URL
@@ -119,6 +196,17 @@ class ESClient:
         )
         await self._create_if_missing(
             INDEX_ITEMS, _item_mapping(cjk_index, cjk_search),
+        )
+        # Unified search (#42) indices. Added here so a single ensure_indexes()
+        # call on startup bootstraps everything; no separate migration step.
+        await self._create_if_missing(
+            INDEX_POSTS, _post_mapping(cjk_index, cjk_search),
+        )
+        await self._create_if_missing(
+            INDEX_REPLIES, _reply_mapping(cjk_index, cjk_search),
+        )
+        await self._create_if_missing(
+            INDEX_TAGS, _tag_mapping(cjk_index, cjk_search),
         )
 
     async def _detect_cjk_analyzers(self) -> tuple[str, str]:
@@ -157,6 +245,52 @@ class ESClient:
 
     async def index_item(self, *, item_id: int, body: dict[str, Any]):
         await self.client.index(index=INDEX_ITEMS, id=str(item_id), document=body)
+
+    # ── unified search write path (#42) ───────────────────────────────
+    # All these are "best-effort" in the sense that callers (router layer)
+    # should log+swallow failures: the primary DB write is authoritative,
+    # ES is a secondary index.
+
+    async def index_post(self, *, post_id: int, body: dict[str, Any]):
+        await self.client.index(index=INDEX_POSTS, id=str(post_id), document=body)
+
+    async def delete_post(self, post_id: int):
+        try:
+            await self.client.delete(index=INDEX_POSTS, id=str(post_id))
+        except NotFoundError:
+            pass
+        # Cascade: drop any replies tied to this post so deleted threads
+        # don't haunt unified search results.
+        try:
+            await self.client.delete_by_query(
+                index=INDEX_REPLIES,
+                body={"query": {"term": {"post_id": post_id}}},
+                refresh=True,
+            )
+        except NotFoundError:
+            pass
+
+    async def index_reply(self, *, reply_id: int, body: dict[str, Any]):
+        await self.client.index(index=INDEX_REPLIES, id=str(reply_id), document=body)
+
+    async def delete_reply(self, reply_id: int):
+        try:
+            await self.client.delete(index=INDEX_REPLIES, id=str(reply_id))
+        except NotFoundError:
+            pass
+
+    async def index_tag(self, *, tag_id: int, body: dict[str, Any]):
+        # Tags live alongside categories — `kind` discriminates. Doc id
+        # uses a namespaced scheme to avoid collisions.
+        composite = f"{body.get('kind', 'tag')}:{tag_id}"
+        await self.client.index(index=INDEX_TAGS, id=composite, document=body)
+
+    async def delete_tag(self, *, tag_id: int, kind: str = "tag"):
+        composite = f"{kind}:{tag_id}"
+        try:
+            await self.client.delete(index=INDEX_TAGS, id=composite)
+        except NotFoundError:
+            pass
 
     async def delete_document(self, doc_id: int):
         """Remove all chunks + item doc for a document (called on doc delete)."""
@@ -222,6 +356,81 @@ class ESClient:
             }
             for hit in resp["hits"]["hits"]
         ]
+
+    # ── unified search read path (#42) ────────────────────────────────
+    async def search_posts(self, q: str, *, size: int = 20) -> dict[str, Any]:
+        resp = await self.client.search(
+            index=INDEX_POSTS,
+            body={
+                "size": size,
+                "query": {
+                    "multi_match": {
+                        "query": q,
+                        "fields": ["title^3", "body"],
+                    }
+                },
+                "highlight": {
+                    "fields": {
+                        "title": {},
+                        "body":  {"fragment_size": 160},
+                    },
+                },
+            },
+        )
+        return _unpack_hits(resp, id_field="id")
+
+    async def search_replies(self, q: str, *, size: int = 20) -> dict[str, Any]:
+        resp = await self.client.search(
+            index=INDEX_REPLIES,
+            body={
+                "size": size,
+                "query": {
+                    "bool": {
+                        "must":   [{"match": {"content": q}}],
+                        # Exclude tombstoned replies — their content is empty
+                        # anyway, but skipping them cuts down on noise.
+                        "filter": [{"term": {"is_deleted": False}}],
+                    }
+                },
+                "highlight": {"fields": {"content": {"fragment_size": 160}}},
+            },
+        )
+        return _unpack_hits(resp, id_field="id")
+
+    async def search_tags(self, q: str, *, size: int = 20) -> dict[str, Any]:
+        resp = await self.client.search(
+            index=INDEX_TAGS,
+            body={
+                "size": size,
+                "query": {
+                    "multi_match": {
+                        "query": q,
+                        "fields": ["name^3", "description"],
+                    }
+                },
+                "highlight": {"fields": {"name": {}, "description": {}}},
+            },
+        )
+        return _unpack_hits(resp, id_field="id")
+
+
+def _unpack_hits(resp: dict[str, Any], *, id_field: str = "id") -> dict[str, Any]:
+    """Shared shape for post/reply/tag search — returns {total, hits: [...]}."""
+    hits = resp.get("hits", {})
+    total = hits.get("total", {})
+    total_n = total.get("value") if isinstance(total, dict) else int(total or 0)
+    return {
+        "total": int(total_n or 0),
+        "hits": [
+            {
+                "id": hit["_source"].get(id_field, hit["_id"]),
+                "score": hit["_score"],
+                "source": hit["_source"],
+                "highlight": hit.get("highlight", {}),
+            }
+            for hit in hits.get("hits", [])
+        ],
+    }
 
 
 es = ESClient()

--- a/backend/app/services/es_client.py
+++ b/backend/app/services/es_client.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from elasticsearch import AsyncElasticsearch, NotFoundError
+from elasticsearch import ApiError, AsyncElasticsearch, BadRequestError, NotFoundError
 
 from app.core.config import settings
 
@@ -36,6 +36,24 @@ INDEX_TAGS = "ekm_tags"
 # Default to IK; if the plugin isn't installed, falls back to `standard`.
 _CJK_ANALYZER_INDEX = "ik_max_word"
 _CJK_ANALYZER_SEARCH = "ik_smart"
+
+
+def _is_already_exists(exc: ApiError) -> bool:
+    """Return True if this ES error is a benign 'index already exists' race.
+
+    ES returns HTTP 400 with error.type = "resource_already_exists_exception"
+    when a concurrent create lost the race. The error body shape is stable
+    across the 8.x client; fall back to the stringified message if the body
+    isn't the dict we expect (some transport layers wrap differently).
+    """
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict) and err.get("type") == "resource_already_exists_exception":
+            return True
+    # Last-resort substring match. Not pretty, but indices.create's API
+    # contract has been stable on this string since ES 5.
+    return "resource_already_exists_exception" in str(exc)
 
 
 def _chunk_mapping(cjk_analyzer_index: str, cjk_analyzer_search: str) -> dict[str, Any]:
@@ -223,10 +241,30 @@ class ESClient:
             return "standard", "standard"
 
     async def _create_if_missing(self, name: str, body: dict[str, Any]):
+        # The exists+create pair is TOCTOU-racy: when multiple workers
+        # start simultaneously (compose / fly boot), two can both see
+        # "not exists" and then both call create(), and the loser gets
+        # a 400 `resource_already_exists_exception`. Elasticsearch's
+        # create is not itself idempotent, so we handle that specific
+        # error as success — any other BadRequestError (e.g. mapping
+        # conflict) still bubbles.
         exists = await self.client.indices.exists(index=name)
         if exists:
             return
-        await self.client.indices.create(index=name, body=body)
+        try:
+            await self.client.indices.create(index=name, body=body)
+        except BadRequestError as exc:
+            if _is_already_exists(exc):
+                log.debug("ES index %s created concurrently by another worker", name)
+                return
+            raise
+        except ApiError as exc:
+            # Some client versions surface this under the generic ApiError
+            # rather than BadRequestError. Belt-and-braces.
+            if _is_already_exists(exc):
+                log.debug("ES index %s created concurrently by another worker", name)
+                return
+            raise
         log.info("created ES index: %s", name)
 
     # ── write path ────────────────────────────────────────────────────

--- a/backend/app/services/search_aggregator.py
+++ b/backend/app/services/search_aggregator.py
@@ -1,0 +1,209 @@
+"""Unified search aggregator (#42 / US-075).
+
+One entry point, fans out to the per-index searches in `es_client`, merges
+results into the grouped response shape the frontend expects:
+
+    {
+        query:  str,
+        total:  int,               # grand total across all requested types
+        results: {
+            documents: { total, hits: [...] },
+            posts:     { total, hits: [...] },
+            tags:      { total, hits: [...] },
+        }
+    }
+
+Design choices:
+
+- "documents" bucket unifies `ekm_items` (metadata: name/description) AND
+  `ekm_chunks` (body content). Hits from both indices are merged and
+  deduplicated by `document_id`, keeping the higher-scoring hit. A chunk
+  hit carries `chunk_index` + highlighted passage so the UI can jump to it;
+  an item hit carries `name` + `description` highlights.
+
+- "posts" bucket unifies `ekm_posts` (title+body) AND `ekm_replies`
+  (comment content). Reply hits include `post_id` so the UI can link back
+  to the thread.
+
+- "tags" bucket covers both Tags and Categories (both live in `ekm_tags`
+  with a `kind` discriminator).
+
+- ES failures on any single index are logged + skipped, not fatal — a
+  degraded search (e.g. posts index missing) is still better than a 500.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Iterable
+
+from app.services.es_client import es
+
+
+log = logging.getLogger(__name__)
+
+
+# Types the frontend can request via ?types=documents,posts,tags
+ALL_TYPES = ("documents", "posts", "tags")
+
+
+async def search_all(
+    q: str,
+    *,
+    types: Iterable[str] | None = None,
+    size: int = 20,
+) -> dict[str, Any]:
+    """Run unified search across the requested content buckets."""
+    requested = _normalize_types(types)
+
+    # Fan out concurrently — each bucket is an independent ES query.
+    jobs: dict[str, asyncio.Task[dict[str, Any]]] = {}
+    if "documents" in requested:
+        jobs["documents"] = asyncio.create_task(_search_documents(q, size=size))
+    if "posts" in requested:
+        jobs["posts"] = asyncio.create_task(_search_posts(q, size=size))
+    if "tags" in requested:
+        jobs["tags"] = asyncio.create_task(_search_tags(q, size=size))
+
+    results: dict[str, dict[str, Any]] = {}
+    for bucket, task in jobs.items():
+        try:
+            results[bucket] = await task
+        except Exception as exc:  # pragma: no cover — ES live path
+            log.warning("unified-search bucket=%s failed: %s", bucket, exc)
+            results[bucket] = {"total": 0, "hits": []}
+
+    grand_total = sum(r.get("total", 0) for r in results.values())
+    return {"query": q, "total": grand_total, "results": results}
+
+
+def _normalize_types(types: Iterable[str] | None) -> set[str]:
+    if not types:
+        return set(ALL_TYPES)
+    requested = {t.strip().lower() for t in types if t and t.strip()}
+    # Silently drop unknown types rather than 400 — keeps the API forward-
+    # compatible with future buckets the frontend may probe for.
+    return requested & set(ALL_TYPES) or set(ALL_TYPES)
+
+
+async def _search_documents(q: str, *, size: int) -> dict[str, Any]:
+    """Merge item-level + chunk-level hits into a single documents bucket.
+
+    The UI expects a flat list of document hits; chunk matches are surfaced
+    inline as a `matched_chunks` array on the parent document entry. We
+    dedupe by `document_id` — if both the item and a chunk matched, we take
+    the max score and attach the chunk excerpts to the item hit.
+    """
+    items = await es.search_items(q, size=size)
+    chunks = await es.search_chunks(q, size=size)
+
+    by_doc: dict[int, dict[str, Any]] = {}
+
+    for it in items:
+        doc_id = int(it["id"])
+        by_doc[doc_id] = {
+            "document_id": doc_id,
+            "score": it.get("score", 0.0),
+            "name": it["source"].get("name"),
+            "description": it["source"].get("description"),
+            "file_type": it["source"].get("file_type"),
+            "highlight": it.get("highlight", {}),
+            "matched_chunks": [],
+        }
+
+    for ch in chunks:
+        doc_id = int(ch["document_id"])
+        entry = by_doc.get(doc_id)
+        excerpt = {
+            "chunk_index": ch["chunk_index"],
+            "score": ch.get("score", 0.0),
+            "content": ch.get("content"),
+            "highlight": ch.get("highlight", {}),
+        }
+        if entry is None:
+            by_doc[doc_id] = {
+                "document_id": doc_id,
+                "score": ch.get("score", 0.0),
+                "name": None,
+                "description": None,
+                "file_type": None,
+                "highlight": {},
+                "matched_chunks": [excerpt],
+            }
+        else:
+            entry["matched_chunks"].append(excerpt)
+            entry["score"] = max(entry["score"], ch.get("score", 0.0))
+
+    merged = sorted(by_doc.values(), key=lambda r: r["score"], reverse=True)
+    # Cap to `size` after merging — we over-fetched per index, so trim now.
+    merged = merged[:size]
+    return {"total": len(merged), "hits": merged}
+
+
+async def _search_posts(q: str, *, size: int) -> dict[str, Any]:
+    """Merge post + reply hits. Reply hits link back to their parent post."""
+    posts = await es.search_posts(q, size=size)
+    replies = await es.search_replies(q, size=size)
+
+    hits: list[dict[str, Any]] = []
+    for p in posts["hits"]:
+        src = p["source"]
+        hits.append({
+            "kind": "post",
+            "post_id": int(src.get("id", p["id"])),
+            "title": src.get("title"),
+            "snippet": _first_highlight(p.get("highlight", {}), ("title", "body"))
+                       or _truncate(src.get("body")),
+            "score": p["score"],
+            "author_id": src.get("author_id"),
+            "created_at": src.get("created_at"),
+        })
+    for r in replies["hits"]:
+        src = r["source"]
+        hits.append({
+            "kind": "reply",
+            "reply_id": int(src.get("id", r["id"])),
+            "post_id": src.get("post_id"),
+            "snippet": _first_highlight(r.get("highlight", {}), ("content",))
+                       or _truncate(src.get("content")),
+            "score": r["score"],
+            "author_id": src.get("author_id"),
+            "created_at": src.get("created_at"),
+        })
+    hits.sort(key=lambda h: h["score"], reverse=True)
+    hits = hits[:size]
+    return {"total": posts["total"] + replies["total"], "hits": hits}
+
+
+async def _search_tags(q: str, *, size: int) -> dict[str, Any]:
+    raw = await es.search_tags(q, size=size)
+    hits = [
+        {
+            "kind": h["source"].get("kind", "tag"),
+            "id": int(h["source"].get("id", h["id"])),
+            "name": h["source"].get("name"),
+            "description": h["source"].get("description"),
+            "slug": h["source"].get("slug"),
+            "color": h["source"].get("color"),
+            "usage_count": h["source"].get("usage_count", 0),
+            "score": h["score"],
+            "highlight": h.get("highlight", {}),
+        }
+        for h in raw["hits"]
+    ]
+    return {"total": raw["total"], "hits": hits}
+
+
+def _first_highlight(highlight: dict[str, Any], fields: tuple[str, ...]) -> str | None:
+    for f in fields:
+        frags = highlight.get(f)
+        if frags:
+            return frags[0]
+    return None
+
+
+def _truncate(s: str | None, n: int = 200) -> str | None:
+    if not s:
+        return None
+    s = s.replace("\n", " ").strip()
+    return s if len(s) <= n else s[: n - 1] + "…"

--- a/backend/app/services/search_aggregator.py
+++ b/backend/app/services/search_aggregator.py
@@ -56,22 +56,34 @@ async def search_all(
     """Run unified search across the requested content buckets."""
     requested = _normalize_types(types)
 
-    # Fan out concurrently — each bucket is an independent ES query.
-    jobs: dict[str, asyncio.Task[dict[str, Any]]] = {}
+    # Fan out concurrently — each bucket is an independent ES query and
+    # should land in parallel. `asyncio.gather(..., return_exceptions=True)`
+    # is the idiomatic form: per-bucket failures come back as the caught
+    # exception in the result slot (we then swap in an empty-bucket
+    # sentinel), while successful buckets return their payload. One
+    # broken index does NOT fail the whole search — partial result beats
+    # a 500 from the caller's perspective.
+    bucket_names: list[str] = []
+    coros: list = []
     if "documents" in requested:
-        jobs["documents"] = asyncio.create_task(_search_documents(q, size=size))
+        bucket_names.append("documents")
+        coros.append(_search_documents(q, size=size))
     if "posts" in requested:
-        jobs["posts"] = asyncio.create_task(_search_posts(q, size=size))
+        bucket_names.append("posts")
+        coros.append(_search_posts(q, size=size))
     if "tags" in requested:
-        jobs["tags"] = asyncio.create_task(_search_tags(q, size=size))
+        bucket_names.append("tags")
+        coros.append(_search_tags(q, size=size))
+
+    gathered = await asyncio.gather(*coros, return_exceptions=True)
 
     results: dict[str, dict[str, Any]] = {}
-    for bucket, task in jobs.items():
-        try:
-            results[bucket] = await task
-        except Exception as exc:  # pragma: no cover — ES live path
-            log.warning("unified-search bucket=%s failed: %s", bucket, exc)
+    for bucket, outcome in zip(bucket_names, gathered):
+        if isinstance(outcome, Exception):
+            log.warning("unified-search bucket=%s failed: %s", bucket, outcome)
             results[bucket] = {"total": 0, "hits": []}
+        else:
+            results[bucket] = outcome
 
     grand_total = sum(r.get("total", 0) for r in results.values())
     return {"query": q, "total": grand_total, "results": results}

--- a/frontend/src/app/(main)/assistant/page.tsx
+++ b/frontend/src/app/(main)/assistant/page.tsx
@@ -171,8 +171,16 @@ export default function AssistantPage() {
               onChange={(e) => setInput(e.target.value)}
               placeholder="向 AI 助手提问…（Shift+Enter 换行）"
               autoSize={{ minRows: 1, maxRows: 6 }}
-              onPressEnter={(e) => {
-                if (!e.shiftKey) {
+              // #90: onPressEnter fires before IME composition end in
+              // some browsers, swallowing the candidate-select Enter of
+              // Chinese input methods. Using onKeyDown + isComposing
+              // guard lets IME users confirm candidates without sending.
+              onKeyDown={(e) => {
+                if (
+                  e.key === 'Enter'
+                  && !e.shiftKey
+                  && !e.nativeEvent.isComposing
+                ) {
                   e.preventDefault()
                   void handleSend()
                 }

--- a/frontend/src/app/(main)/editor/page.tsx
+++ b/frontend/src/app/(main)/editor/page.tsx
@@ -316,8 +316,20 @@ export default function EditorPage() {
                 placeholder="向 AI 提问…"
                 autoSize={{ minRows: 1, maxRows: 4 }}
                 className="text-xs flex-1"
-                onPressEnter={(e) => {
-                  if (!e.shiftKey) { e.preventDefault(); handleSend() }
+                // #90: switched off onPressEnter because it fires before
+                // IME composition end on some browsers (Chinese input
+                // methods confirm candidates with Enter). Using onKeyDown
+                // + nativeEvent.isComposing skips the confirm Enter and
+                // only sends on a "real" Enter press.
+                onKeyDown={(e) => {
+                  if (
+                    e.key === 'Enter'
+                    && !e.shiftKey
+                    && !e.nativeEvent.isComposing
+                  ) {
+                    e.preventDefault()
+                    void handleSend()
+                  }
                 }}
               />
               <Button


### PR DESCRIPTION
解决 Issue #42 (US-075 统一全文索引库) 与 Issue #90 (AI 助手 Enter 键 bug)，按 Zoey 要求合进一个 PR。

## #42 — 统一全文索引库 (US-075)

**新增统一搜索端点**：`GET /api/v1/search?q=关键词&types=documents,posts,tags&size=20`

响应形状：

\`\`\`json
{
  \"query\": \"关键词\",
  \"total\": 42,
  \"results\": {
    \"documents\": { \"total\": 12, \"hits\": [...] },
    \"posts\":     { \"total\": 20, \"hits\": [...] },
    \"tags\":      { \"total\": 10, \"hits\": [...] }
  }
}
\`\`\`

### 覆盖 4 类内容（Zoey 需求）

| 类型 | 索引 | 合并策略 |
|---|---|---|
| 文档（主文档 + 附件）| `ekm_items` + `ekm_chunks` | 按 document_id 合并，chunk 命中以 `matched_chunks` 附在主文档条目上 |
| 帖子 / 评论 | `ekm_posts` + `ekm_replies`（新）| post 和 reply 扁平混排，各带 `kind` 区分；reply 带 `post_id` 反链 |
| 标签 / 分类 | `ekm_tags`（新，`kind` 字段区分）| 共用一个 mapping，UI 用 `kind: \"tag\" \| \"category\"` 区分 |

### 设计要点

1. **并发 fan-out**：`search_aggregator.py` 用 `asyncio.create_task` 并发发起 3 个桶的 ES 查询，聚合后返回。单桶失败不会拖垮整个请求 —— 降级成空桶 + 日志告警，partial result 好过 500。

2. **两阶段写入**（post/reply/tag/category 的 create/update/delete）：先 `db.commit()` 落盘，再 `await es.index_*()`。ES 挂了不会回滚 DB 写入，只会让该条记录在统一搜索里暂时缺失，Ops 可以后续跑 reindex 脚本补齐。

3. **CJK 分词跟现有一致**：复用 `es_client._detect_cjk_analyzers()` 探测机制，IK 装了就用 `ik_max_word` / `ik_smart`，没装就 fallback 到 `standard`，`ensure_indexes()` 在 app 启动时 idempotent bootstrap 三个新索引。

4. **与 #48 (PR #91) 的关系**：#48 的 KG 流水线已经在写 `ekm_chunks`（文档内容层），本 PR 做消费侧 —— 统一搜索 API 把 `ekm_chunks` 已有的索引用起来，同时补上帖子/评论/标签/分类的索引写入（#48 没覆盖这部分）。

### 索引写入钩子

- `routers/community.py`：`POST /posts` → 写 `ekm_posts`；`POST /replies` → 写 `ekm_replies` 并重刷父 post；`DELETE /replies/{id}`（软删）→ 同上，`is_deleted=True` 在搜索里把内容变空串
- `routers/tags.py`：`POST /tags`、`PATCH /tags/{id}`、`DELETE /tags/{id}` → `ekm_tags` 写 / 更新 / 删，`kind=\"tag\"`
- `routers/categories.py`：同上，`kind=\"category\"`

所有钩子都是 best-effort（try/except + log.warning），不阻塞用户操作。

## #90 — AI 助手 Enter 键 bug

**根因**：`frontend/src/app/(main)/editor/page.tsx:319` 和 `assistant/page.tsx:174` 都用了 Ant Design 的 `onPressEnter`。在中文 IME 输入法场景下，`onPressEnter` 会在 IME composition 结束前触发，导致：

- 用户按 Enter 确认输入法候选词时，可能被误识为发送
- 某些浏览器（尤其 Safari + 中文输入法）下 `onPressEnter` 对组合事件的处理不一致，出现「Enter 无反应」的症状

**修法**：换成 `onKeyDown` + `e.nativeEvent.isComposing` 守卫：

\`\`\`tsx
onKeyDown={(e) => {
  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
    e.preventDefault()
    void handleSend()
  }
}}
\`\`\`

- \`!e.shiftKey\` 继续保留 Shift+Enter = 换行语义
- \`!e.nativeEvent.isComposing\` 确保 IME 组合中的 Enter 只被用于确认候选词，不触发发送

两个页面都修了（editor 是 bug 出现处；assistant 顺手做防御性一致性修复）。

## 改动文件

\`\`\`
backend/app/routers/categories.py      |  32 +++++
backend/app/routers/community.py       |  53 ++++++++
backend/app/routers/search.py          |  40 +++++-
backend/app/routers/tags.py            |  32 +++++
backend/app/services/es_client.py      | 209 +++++++++++++++++++++++++++++
backend/app/services/search_aggregator.py (新) | 209 +++++++
frontend/.../assistant/page.tsx        |  12 +-
frontend/.../editor/page.tsx           |  16 ++-
\`\`\`

## 前端对接

现有 `/search` 页面原本调 `/api/v1/search/items`（只搜文档）。新端点 `/api/v1/search`（无 /items 后缀）返回分组结果，前端对接时切 URL + 按 `results.{documents,posts,tags}` 渲染分组 UI 即可。本 PR 不动前端搜索页（保持独立改动范围），follow-up issue 里接。

## 部署注意（Ops / Raven）

- 不需要 Alembic 迁移。ES 索引会在 app 启动时通过 `ensure_indexes()` 自动创建（idempotent）。
- Staging 部署后建议 Ops 手动跑一次全量 reindex 把历史帖子/标签补进去（后续再提 admin reindex 端点）。
- IK 分词插件在 ES 镜像里已装（8.13.4-ik），mapping 里 `ik_max_word` 分词器。

## 其它

- 此 PR 基于 `main` 最新（\`856c2176\` 之后合入的 #89 batch-ops 之上）
- 跟 PR #91（#48 KG 流水线）无 merge 冲突 —— 两个 PR 改动集完全独立
- LLM 配置命名问题（\`LLM_BASE_URL\` vs \`LLM_API_BASE\`）另信请 Zoey 拍板，本 PR 不涉及

—— Kira