### PR TITLE
feat: #49 Agent API — /api/agent/* with scoped Bearer tokens

### DIFF
--- a/backend/alembic/versions/0010_agent_tokens.py
+++ b/backend/alembic/versions/0010_agent_tokens.py
@@ -1,0 +1,76 @@
+"""agent_tokens table (#49).
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-20
+
+US-113/114: long-lived Bearer credentials for external Agent callers.
+See app/models/agent.py for the design rationale behind prefix+hash.
+
+Why a new table instead of reusing users:
+  - Agents aren't people. They don't have passwords, emails, sessions.
+  - Scopes on an Agent token are declarative (`knowledge:read`, `kg:write`)
+    and composable; roles on a User are coarse and mutually exclusive.
+  - Different revocation lifecycle — admin rotates the Agent secret, user
+    changes password. Keeping them apart avoids auth-code coupling.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010"
+down_revision: Union[str, None] = "0009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        # Unique index on prefix — O(1) lookup without exposing the secret.
+        sa.Column("token_prefix", sa.String(length=32), nullable=False),
+        sa.Column("token_hash", sa.String(length=255), nullable=False),
+        # JSON scopes: ["knowledge:read", "kg:read", "kg:write"].
+        sa.Column(
+            "scopes", sa.JSON(), nullable=False,
+            server_default=sa.text("'[]'::json"),
+        ),
+        sa.Column(
+            "created_by_id", sa.Integer(),
+            # RESTRICT — preserve audit trail of who provisioned the key.
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True),
+            server_default=sa.func.now(), nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(),
+            server_default=sa.true(), nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_agent_tokens_token_prefix",
+        "agent_tokens", ["token_prefix"], unique=True,
+    )
+    op.create_index(
+        "ix_agent_tokens_created_by_id",
+        "agent_tokens", ["created_by_id"],
+    )
+    op.create_index(
+        "ix_agent_tokens_is_active",
+        "agent_tokens", ["is_active"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_tokens_is_active", table_name="agent_tokens")
+    op.drop_index("ix_agent_tokens_created_by_id", table_name="agent_tokens")
+    op.drop_index("ix_agent_tokens_token_prefix", table_name="agent_tokens")
+    op.drop_table("agent_tokens")

--- a/backend/app/core/agent_deps.py
+++ b/backend/app/core/agent_deps.py
@@ -25,11 +25,12 @@ Design notes:
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -37,6 +38,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.agent_security import extract_prefix, verify_agent_token
 from app.core.database import get_db
 from app.models.agent import AgentToken
+
+
+log = logging.getLogger(__name__)
 
 
 # Known scopes. New entries here must be documented in the API docs.
@@ -78,14 +82,18 @@ def _unauthorized(detail: str) -> HTTPException:
 async def _resolve_agent(
     credentials: HTTPAuthorizationCredentials | None,
     db: AsyncSession,
+    request: Request,
 ) -> AgentCaller:
+    client_host = request.client.host if request.client else "unknown"
+
     if credentials is None:
+        log.warning("agent_auth_failed reason=missing_token client=%s", client_host)
         raise _unauthorized("Missing Bearer token")
 
     plaintext = credentials.credentials
     prefix = extract_prefix(plaintext)
     if prefix is None:
-        # Don't even hit the DB if the shape is obviously wrong.
+        log.warning("agent_auth_failed reason=malformed_token client=%s", client_host)
         raise _unauthorized("Invalid Agent token")
 
     stmt = select(AgentToken).where(
@@ -94,15 +102,24 @@ async def _resolve_agent(
     )
     row: AgentToken | None = (await db.execute(stmt)).scalar_one_or_none()
     if row is None:
+        log.warning(
+            "agent_auth_failed reason=unknown_or_inactive_prefix prefix=%s client=%s",
+            prefix, client_host,
+        )
         raise _unauthorized("Invalid Agent token")
 
     if row.expires_at is not None and row.expires_at < datetime.now(timezone.utc):
+        log.warning(
+            "agent_auth_failed reason=expired token_id=%d prefix=%s client=%s",
+            row.id, prefix, client_host,
+        )
         raise _unauthorized("Agent token expired")
 
     if not verify_agent_token(plaintext, row.token_hash):
-        # Prefix collision (or someone guessing) — hash mismatch is the
-        # real auth check. Log nothing here to avoid noise; DB-layer
-        # metrics will catch brute-force attempts.
+        log.warning(
+            "agent_auth_failed reason=hash_mismatch prefix=%s client=%s",
+            prefix, client_host,
+        )
         raise _unauthorized("Invalid Agent token")
 
     # Bump last_used_at. Part of the same AsyncSession so it lands on
@@ -129,12 +146,13 @@ def require_agent_scope(*required: str):
         )
 
     async def _dep(
+        request: Request,
         credentials: Annotated[
             HTTPAuthorizationCredentials | None, Depends(_bearer)
         ],
         db: Annotated[AsyncSession, Depends(get_db)],
     ) -> AgentCaller:
-        agent = await _resolve_agent(credentials, db)
+        agent = await _resolve_agent(credentials, db, request)
         if not set(required).issubset(agent.scopes):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/core/agent_deps.py
+++ b/backend/app/core/agent_deps.py
@@ -1,0 +1,152 @@
+"""FastAPI dependency: authenticate an Agent Bearer token + scope-check.
+
+Usage in a router::
+
+    from app.core.agent_deps import require_agent_scope, AgentCaller
+
+    @router.get("/kg/query")
+    async def kg_query(
+        agent: AgentCaller = Depends(require_agent_scope("kg:read")),
+        ...
+    ):
+        ...
+
+Design notes:
+
+* Separate dependency chain from user auth — an Agent token must NOT be
+  accepted on user endpoints and vice versa. We return an `AgentCaller`
+  dataclass (not a `User`) so the type system catches accidental mixing
+  in the router signatures.
+* `last_used_at` is bumped on every successful authentication. The flush
+  is deferred to the normal request-commit path (AsyncSession transaction)
+  to keep the hot path on a single DB round-trip.
+* Scope check is substring-free string equality. If we need hierarchy
+  later (e.g. `kg:*`) we'll extend here, not at call sites.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_security import extract_prefix, verify_agent_token
+from app.core.database import get_db
+from app.models.agent import AgentToken
+
+
+# Known scopes. New entries here must be documented in the API docs.
+KNOWN_SCOPES: frozenset[str] = frozenset({
+    "knowledge:read",   # vector + ES search
+    "kg:read",          # Neo4j read (query, path)
+    "kg:write",         # KG node upsert
+})
+
+
+@dataclass(frozen=True)
+class AgentCaller:
+    """Authenticated Agent — the request-scoped view of an AgentToken.
+
+    Frozen so handlers can't mutate credentials mid-request. We pass the
+    DB row's primary key (not the row itself) to make it obvious this
+    isn't a session-attached entity — side-effects like auditing should
+    go through a fresh query, not this object.
+    """
+    token_id: int
+    name: str
+    scopes: frozenset[str]
+
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    # Uniform 401 — we don't reveal whether it's the prefix, the hash,
+    # or the scope that failed. Returning different messages for
+    # "wrong scope" vs "no such token" leaks info to an attacker probing.
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail={"code": "AGENT_UNAUTHORIZED", "message": detail},
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def _resolve_agent(
+    credentials: HTTPAuthorizationCredentials | None,
+    db: AsyncSession,
+) -> AgentCaller:
+    if credentials is None:
+        raise _unauthorized("Missing Bearer token")
+
+    plaintext = credentials.credentials
+    prefix = extract_prefix(plaintext)
+    if prefix is None:
+        # Don't even hit the DB if the shape is obviously wrong.
+        raise _unauthorized("Invalid Agent token")
+
+    stmt = select(AgentToken).where(
+        AgentToken.token_prefix == prefix,
+        AgentToken.is_active.is_(True),
+    )
+    row: AgentToken | None = (await db.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        raise _unauthorized("Invalid Agent token")
+
+    if row.expires_at is not None and row.expires_at < datetime.now(timezone.utc):
+        raise _unauthorized("Agent token expired")
+
+    if not verify_agent_token(plaintext, row.token_hash):
+        # Prefix collision (or someone guessing) — hash mismatch is the
+        # real auth check. Log nothing here to avoid noise; DB-layer
+        # metrics will catch brute-force attempts.
+        raise _unauthorized("Invalid Agent token")
+
+    # Bump last_used_at. Part of the same AsyncSession so it lands on
+    # the request's commit — one fewer round-trip than a separate write.
+    row.last_used_at = datetime.now(timezone.utc)
+    await db.flush()
+
+    # Validate scopes against KNOWN_SCOPES — silently drop anything
+    # unknown so stale DB rows don't leak privileges if we rename a scope.
+    raw_scopes = row.scopes or []
+    clean_scopes = frozenset(s for s in raw_scopes if s in KNOWN_SCOPES)
+    return AgentCaller(token_id=row.id, name=row.name, scopes=clean_scopes)
+
+
+def require_agent_scope(*required: str):
+    """Build a dependency that enforces the given scope(s).
+
+    All listed scopes must be present on the token. Multiple scopes are
+    AND-combined; for OR semantics, pick one and document at the route."""
+    missing_sentinel = set(required) - KNOWN_SCOPES
+    if missing_sentinel:
+        raise ValueError(
+            f"require_agent_scope called with unknown scope(s): {missing_sentinel}"
+        )
+
+    async def _dep(
+        credentials: Annotated[
+            HTTPAuthorizationCredentials | None, Depends(_bearer)
+        ],
+        db: Annotated[AsyncSession, Depends(get_db)],
+    ) -> AgentCaller:
+        agent = await _resolve_agent(credentials, db)
+        if not set(required).issubset(agent.scopes):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "AGENT_SCOPE_FORBIDDEN",
+                    "message": "Token lacks required scope",
+                    # Echoing required scopes is intentional — lets the
+                    # caller fix their provisioning. Unlike the 401 path,
+                    # here we already know the token is valid.
+                    "required": sorted(required),
+                },
+            )
+        return agent
+
+    return _dep

--- a/backend/app/core/agent_security.py
+++ b/backend/app/core/agent_security.py
@@ -1,0 +1,84 @@
+"""Agent token primitives — generation, hashing, constant-time verify.
+
+Kept in its own module (not bolted onto `core/security.py`) because the
+Agent-token lifecycle is distinct from user JWTs:
+
+* Format: ``ekmat_<48 hex chars>`` — the prefix lets ops grep logs for
+  leaked tokens and lets HQ block-list the class of credential. 48 hex
+  chars = 192 bits of entropy, comfortably above "brute force is cheap".
+* Storage: bcrypt-hashed (salted), so two identical tokens hash
+  differently — that's why lookup is by `token_prefix` not hash equality.
+* Verification: bcrypt's native `checkpw` is the constant-time compare.
+
+No JWT. Agent tokens are opaque random strings; revocation means flipping
+``is_active = False`` on the row. JWTs would require a blocklist to get
+the same guarantee, and we'd have gained nothing in return.
+"""
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+
+import bcrypt
+
+
+# Prefix is deliberate:
+#   * `ekm`   — project namespace
+#   * `at`    — "agent token" (distinguishes from a hypothetical `ekmu_` user key)
+#   * `_`     — visual separator
+# Users can copy/paste an ekmat_ and instantly tell what it is.
+TOKEN_PREFIX_SIGIL = "ekmat_"
+
+# First 12 chars of plaintext stored as `token_prefix` for indexed lookup.
+# Includes the sigil + 6 hex chars — enough to be uniqueish for search,
+# short enough to keep the DB index tight. Collision risk at 6 hex = 2^24
+# is acceptable; the actual uniqueness is enforced by the hash check.
+PREFIX_LEN = 12
+
+# 24 random bytes → 48 hex chars body. Combined with the 6-char sigil
+# the full token is 54 chars, easy to copy-paste, no ambiguous glyphs.
+TOKEN_BODY_BYTES = 24
+
+
+@dataclass(frozen=True)
+class NewAgentToken:
+    """Plaintext + derived fields returned by generation. Plaintext is
+    only visible at creation time — it's hashed before persistence."""
+    plaintext: str       # full token — show this to the caller ONCE
+    prefix: str          # PREFIX_LEN-char lookup key stored in DB
+    hashed: str          # bcrypt hash stored in DB
+
+
+def generate_agent_token() -> NewAgentToken:
+    """Mint a new plaintext token + its storage form.
+
+    The caller is responsible for persisting `prefix` and `hashed` and
+    for displaying `plaintext` to the provisioning admin exactly once.
+    After that the plaintext is unrecoverable — if lost, rotate.
+    """
+    body = secrets.token_hex(TOKEN_BODY_BYTES)
+    plaintext = f"{TOKEN_PREFIX_SIGIL}{body}"
+    prefix = plaintext[:PREFIX_LEN]
+    hashed = bcrypt.hashpw(plaintext.encode(), bcrypt.gensalt()).decode()
+    return NewAgentToken(plaintext=plaintext, prefix=prefix, hashed=hashed)
+
+
+def extract_prefix(plaintext: str) -> str | None:
+    """Return the lookup prefix for a candidate token, or None if it's
+    obviously malformed. Cheap pre-check before hitting the DB."""
+    if not plaintext or not plaintext.startswith(TOKEN_PREFIX_SIGIL):
+        return None
+    if len(plaintext) < PREFIX_LEN:
+        return None
+    return plaintext[:PREFIX_LEN]
+
+
+def verify_agent_token(plaintext: str, hashed: str) -> bool:
+    """Constant-time verify. Wraps bcrypt.checkpw so callers don't need
+    to know the encoding dance."""
+    try:
+        return bcrypt.checkpw(plaintext.encode(), hashed.encode())
+    except ValueError:
+        # Bad hash format in DB — treat as no-match, not as a crash. The
+        # only way this fires is a corrupt row, which is a data issue.
+        return False

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,34 @@
+"""Rate limiting for the Agent API.
+
+Uses slowapi with an in-memory backend (sufficient for single-instance
+deployments). If we scale horizontally, swap to the Redis backend via
+``Limiter(storage_uri=settings.REDIS_URL)``.
+
+Key function: extracts the Agent Bearer token prefix from the
+Authorization header so each provisioned token has its own rate bucket.
+Falls back to client IP when no Bearer token is present (pre-auth
+rejection still gets rate-limited to prevent brute-force probing).
+"""
+from __future__ import annotations
+
+from slowapi import Limiter
+from starlette.requests import Request
+
+from app.core.agent_security import TOKEN_PREFIX_SIGIL
+
+
+def _agent_key(request: Request) -> str:
+    """Extract rate-limit key: token prefix or client IP."""
+    auth = request.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip()
+        # Token format: ekmat_<48 hex>. Prefix = first 12 chars.
+        if token.startswith(TOKEN_PREFIX_SIGIL) and len(token) >= 12:
+            return f"agent:{token[:12]}"
+    return f"ip:{request.client.host if request.client else 'unknown'}"
+
+
+limiter = Limiter(key_func=_agent_key)
+
+# Default rate for all agent endpoints. Individual routes can override.
+AGENT_RATE = "60/minute"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.routers import notifications
 from app.routers import archive as archive_router
 from app.routers import restore as restore_router
 from app.routers import batch as batch_router
+from app.routers import agent as agent_router
 
 
 @asynccontextmanager
@@ -100,6 +101,7 @@ app.include_router(notifications.router)
 app.include_router(archive_router.router)
 app.include_router(restore_router.router)
 app.include_router(batch_router.router)
+app.include_router(agent_router.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,11 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
 from app.core.config import settings
+from app.core.rate_limit import limiter
 from app.routers import health
 from app.routers import auth
 from app.routers import files
@@ -69,6 +73,10 @@ app = FastAPI(
     openapi_url="/openapi.json",
     lifespan=lifespan,
 )
+
+# Rate limiting (Agent API)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # CORS
 app.add_middleware(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.feedback import ChatFeedback, FeedbackRating
 from app.models.notification import Notification, NotificationType
 from app.models.archive import ArchiveRule
 from app.models.restore import ArchiveRestoreRequest, RestoreStatus
+from app.models.agent import AgentToken
 
 __all__ = [
     "User", "UserRole",
@@ -22,4 +23,5 @@ __all__ = [
     "Notification", "NotificationType",
     "ArchiveRule",
     "ArchiveRestoreRequest", "RestoreStatus",
+    "AgentToken",
 ]

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -1,0 +1,83 @@
+"""AgentToken — long-lived Bearer credential for external Agent callers.
+
+Kept deliberately separate from User + user JWTs:
+
+* Users have passwords, sessions, refresh flows, roles. Agents don't —
+  an Agent is just a blob of scopes bound to a hashed secret.
+* Users authenticate via short-lived access tokens (minutes). Agent tokens
+  are long-lived (months/years) and rotated by re-issuing.
+* Compromise response differs: a leaked user token is user-specific; a
+  leaked Agent token may have broad scopes across tenants. Separate
+  storage + lookup path makes revocation explicit.
+
+Storage model:
+
+* `token_prefix`  — first 12 chars of the plaintext token (indexed).
+  Gives an O(1) lookup path without leaking the secret.
+* `token_hash`    — bcrypt hash of the FULL plaintext token. The secret
+  itself is never stored. Verified against incoming Bearer on every call.
+* `scopes`        — JSON array of stable string scopes. Start minimal
+  (`knowledge:read`, `kg:read`, `kg:write`); more can be added without
+  a schema change.
+
+The prefix-then-hash pattern is the same design GitHub / Stripe use for
+API keys: you search by prefix, then constant-time-compare the hash. We
+can't look up purely by hash (bcrypt hashes are salted, so the same token
+hashes differently every time), and we shouldn't search by raw equality
+on the plaintext.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean, DateTime, ForeignKey, Integer, JSON, String, func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class AgentToken(Base):
+    __tablename__ = "agent_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    # Human-readable label: "Tom KG Constructor", "Analytics Bot v2", etc.
+    # Not globally unique — two prod/staging keys for the same caller is fine.
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    # First 12 chars of the plaintext token, e.g. "ekmat_4a7f1c".
+    # Indexed + unique so lookup is O(1) without seeing the secret.
+    token_prefix: Mapped[str] = mapped_column(
+        String(32), unique=True, index=True, nullable=False,
+    )
+    # bcrypt hash of full plaintext. Verified on every request.
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # JSON list of scope strings. Validated against a known set at
+    # dependency time (see app/core/agent_deps.py).
+    scopes: Mapped[list] = mapped_column(JSON, default=list, nullable=False)
+
+    # RESTRICT — keep audit trail even if the provisioning admin leaves.
+    # An admin must explicitly reassign or revoke their tokens.
+    created_by_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
+    # Bumped on every successful authenticated call. Used for "is this
+    # token actually in use?" dashboards + stale-key pruning.
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    # Nullable = never expires. Revocation path is `is_active=False`.
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    created_by: Mapped["User"] = relationship("User")  # noqa: F821
+
+    def __repr__(self) -> str:
+        return f"<AgentToken id={self.id} name={self.name!r} prefix={self.token_prefix}>"

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -27,9 +27,10 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from app.core.agent_deps import AgentCaller, require_agent_scope
+from app.core.rate_limit import AGENT_RATE, limiter
 from app.core.graph import graph
 from app.schemas.agent import (
     KGNode,
@@ -72,7 +73,9 @@ router = APIRouter(prefix="/api/agent", tags=["agent"])
         "Requires scope: `knowledge:read`."
     ),
 )
+@limiter.limit(AGENT_RATE)
 async def knowledge_search(
+    request: Request,
     q: str = Query(..., min_length=1, max_length=500, description="Query string"),
     top_k: int = Query(
         10, ge=1, le=50,
@@ -150,7 +153,9 @@ async def knowledge_search(
         "Requires scope: `kg:read`."
     ),
 )
+@limiter.limit(AGENT_RATE)
 async def kg_query(
+    request: Request,
     body: KGQueryRequest,
     agent: AgentCaller = Depends(require_agent_scope("kg:read")),
 ) -> KGQueryResponse:
@@ -199,7 +204,9 @@ async def kg_query(
         "Requires scope: `kg:write`."
     ),
 )
+@limiter.limit(AGENT_RATE)
 async def kg_node_upsert(
+    request: Request,
     body: KGNodeUpsertRequest,
     agent: AgentCaller = Depends(require_agent_scope("kg:write")),
 ) -> KGNodeUpsertResponse:
@@ -241,7 +248,9 @@ async def kg_node_upsert(
         "Requires scope: `kg:read`."
     ),
 )
+@limiter.limit(AGENT_RATE)
 async def kg_path(
+    request: Request,
     source: str = Query(..., min_length=1, max_length=255, alias="source"),
     target: str = Query(..., min_length=1, max_length=255, alias="target"),
     max_hops: int = Query(3, ge=1, le=5),

--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -1,0 +1,279 @@
+"""Agent API (#49 / US-113/US-114).
+
+External-facing REST surface for Agent integrations (e.g. Tom's KG
+constructor). Mounted under ``/api/agent``, authenticated with an Agent
+Bearer token distinct from user JWTs.
+
+Endpoints:
+
+    GET  /api/agent/knowledge/search   hybrid semantic + full-text search
+    POST /api/agent/kg/query           structured KG query (safe Cypher)
+    POST /api/agent/kg/node            upsert a KG node
+    GET  /api/agent/kg/path            shortest path between two entities
+
+Design notes:
+
+* Each endpoint carries a ``Depends(require_agent_scope(...))`` guard.
+  Scope names are narrow (``knowledge:read``, ``kg:read``, ``kg:write``)
+  and an Agent can be provisioned with only the subset it needs.
+* Cypher safety is delegated to ``services/kg_query.py``. The router's
+  only job is to pipe validated Pydantic input into the builder and hand
+  the resulting parameterised Cypher to Neo4j.
+* Failures from downstream stores (ES, Qdrant, Neo4j) degrade rather than
+  500 where possible — Tom's Agent should see a partial or empty result
+  instead of an outage. Unexpected errors still bubble.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.agent_deps import AgentCaller, require_agent_scope
+from app.core.graph import graph
+from app.schemas.agent import (
+    KGNode,
+    KGNodeUpsertRequest,
+    KGNodeUpsertResponse,
+    KGPathResponse,
+    KGQueryRequest,
+    KGQueryResponse,
+    SearchHit,
+    SearchResponse,
+)
+from app.services.embeddings import embedder
+from app.services.es_client import es
+from app.services.graph_sync import upsert_entity
+from app.services.kg_query import (
+    KGQueryError,
+    build_match_query,
+    build_path_query,
+)
+from app.services.qdrant_client import search as qdrant_search
+
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agent", tags=["agent"])
+
+
+# ── /knowledge/search ─────────────────────────────────────────────────
+
+@router.get(
+    "/knowledge/search",
+    response_model=SearchResponse,
+    summary="Hybrid knowledge search (vector + full-text)",
+    description=(
+        "Run a combined semantic (Qdrant) + full-text (Elasticsearch) "
+        "search over indexed knowledge chunks. Results from both indices "
+        "are merged and de-duplicated by (document_id, chunk_index), "
+        "keeping the higher-scoring match. Partial failures on either "
+        "backend degrade to an empty contribution rather than a 500.\n\n"
+        "Requires scope: `knowledge:read`."
+    ),
+)
+async def knowledge_search(
+    q: str = Query(..., min_length=1, max_length=500, description="Query string"),
+    top_k: int = Query(
+        10, ge=1, le=50,
+        description="Max hits returned (shared budget across backends).",
+    ),
+    agent: AgentCaller = Depends(require_agent_scope("knowledge:read")),
+) -> SearchResponse:
+    # ── vector side ────
+    # embedder is sync (LiteLLM is blocking); calling it from an async
+    # handler is fine for short queries — the cost is single-digit ms.
+    vector_hits: list[dict] = []
+    try:
+        vectors = embedder.embed([q])
+        if vectors:
+            vector_hits = qdrant_search(vectors[0], top_k=top_k)
+    except Exception as exc:  # noqa: BLE001 — degradable
+        log.warning("agent-search vector backend failed: %s", exc)
+
+    # ── full-text side ────
+    # Reuse chunk-level ES search so semantic + full-text results have
+    # the same shape (doc_id + chunk_index + content + score).
+    fulltext_hits: list[dict] = []
+    try:
+        fulltext_hits = await es.search_chunks(q, size=top_k)
+    except Exception as exc:  # noqa: BLE001 — degradable
+        log.warning("agent-search fulltext backend failed: %s", exc)
+
+    # ── merge + dedupe ────
+    # Dedup key: (document_id, chunk_index). Score comparison uses raw
+    # scores which aren't commensurable across backends, so we keep
+    # whichever is higher as a proxy for "more confident". It's a known
+    # heuristic; a proper RRF rerank is follow-up work.
+    merged: dict[tuple[int, int | None], SearchHit] = {}
+
+    for h in vector_hits:
+        key = (int(h["document_id"]), h.get("chunk_index"))
+        hit = SearchHit(
+            document_id=int(h["document_id"]),
+            chunk_index=h.get("chunk_index"),
+            content=h.get("content"),
+            score=float(h.get("score", 0.0)),
+            source="vector",
+        )
+        merged[key] = hit
+
+    for h in fulltext_hits:
+        key = (int(h["document_id"]), h.get("chunk_index"))
+        new_score = float(h.get("score", 0.0))
+        existing = merged.get(key)
+        if existing is None or new_score > existing.score:
+            merged[key] = SearchHit(
+                document_id=int(h["document_id"]),
+                chunk_index=h.get("chunk_index"),
+                content=h.get("content"),
+                score=new_score,
+                source="fulltext",
+            )
+
+    hits = sorted(merged.values(), key=lambda x: x.score, reverse=True)[:top_k]
+    return SearchResponse(query=q, hits=hits)
+
+
+# ── /kg/query ─────────────────────────────────────────────────────────
+
+@router.post(
+    "/kg/query",
+    response_model=KGQueryResponse,
+    summary="Structured knowledge-graph query",
+    description=(
+        "Run a structured query over the knowledge graph. The request "
+        "describes what to match (entity type, property filters, limit) "
+        "and the server builds parameterised Cypher. Raw Cypher strings "
+        "are NEVER accepted — every label, relation type, and property "
+        "key is validated against a controlled vocabulary.\n\n"
+        "Requires scope: `kg:read`."
+    ),
+)
+async def kg_query(
+    body: KGQueryRequest,
+    agent: AgentCaller = Depends(require_agent_scope("kg:read")),
+) -> KGQueryResponse:
+    try:
+        built = build_match_query(
+            entity_type=body.entity_type,
+            where_props=body.where,
+            limit=body.limit,
+        )
+    except KGQueryError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "KG_QUERY_INVALID", "message": str(exc)},
+        )
+
+    try:
+        rows = await graph.run(built.cypher, built.params)
+    except Exception as exc:  # noqa: BLE001
+        # Graph down = empty result, not 500 — consistent with graph_sync.
+        log.warning("agent kg_query failed: %s", exc)
+        return KGQueryResponse(nodes=[])
+
+    nodes = [
+        KGNode(
+            external_id=r.get("external_id"),
+            label=r.get("label"),
+            labels=list(r.get("labels") or []),
+            properties=dict(r.get("properties") or {}),
+        )
+        for r in rows
+        if r.get("external_id")
+    ]
+    return KGQueryResponse(nodes=nodes)
+
+
+# ── /kg/node ──────────────────────────────────────────────────────────
+
+@router.post(
+    "/kg/node",
+    response_model=KGNodeUpsertResponse,
+    summary="Create or update a knowledge-graph node",
+    description=(
+        "Idempotent MERGE on `external_id`. The entity_type must be one "
+        "of the controlled-vocabulary labels; unknown types fall back to "
+        "`Entity` and a warning is logged.\n\n"
+        "Requires scope: `kg:write`."
+    ),
+)
+async def kg_node_upsert(
+    body: KGNodeUpsertRequest,
+    agent: AgentCaller = Depends(require_agent_scope("kg:write")),
+) -> KGNodeUpsertResponse:
+    # graph_sync.upsert_entity already swallows failures + logs a
+    # warning (it's best-effort from the ingestion pipeline's POV).
+    # For the Agent API we promote that to a 503: the Agent asked us to
+    # do a thing and we can't confirm it happened. Having it silently
+    # succeed would break Tom's "did my write land?" contract.
+    from app.core.graph import graph as _g
+    healthy = await _g.healthcheck()
+    if not healthy:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "KG_UNAVAILABLE", "message": "Neo4j is unreachable"},
+        )
+
+    await upsert_entity(
+        external_id=body.external_id,
+        label=body.label,
+        entity_type=body.entity_type,
+        properties=body.properties or {},
+    )
+    # upsert_entity doesn't distinguish create vs update — MERGE semantics
+    # don't give us that cheaply. Report 'upserted' for honesty.
+    return KGNodeUpsertResponse(external_id=body.external_id, status="upserted")
+
+
+# ── /kg/path ──────────────────────────────────────────────────────────
+
+@router.get(
+    "/kg/path",
+    response_model=KGPathResponse,
+    summary="Shortest path between two KG nodes",
+    description=(
+        "Find the shortest path (by hop count) between two entities. The "
+        "hop budget is capped server-side (see services/kg_query.MAX_HOPS). "
+        "Returns `found=false` + empty arrays when no path exists within "
+        "the budget.\n\n"
+        "Requires scope: `kg:read`."
+    ),
+)
+async def kg_path(
+    source: str = Query(..., min_length=1, max_length=255, alias="source"),
+    target: str = Query(..., min_length=1, max_length=255, alias="target"),
+    max_hops: int = Query(3, ge=1, le=5),
+    relation_type: str | None = Query(None, max_length=64),
+    agent: AgentCaller = Depends(require_agent_scope("kg:read")),
+) -> KGPathResponse:
+    try:
+        built = build_path_query(
+            source_external_id=source,
+            target_external_id=target,
+            max_hops=max_hops,
+            relation_type=relation_type,
+        )
+    except KGQueryError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "KG_QUERY_INVALID", "message": str(exc)},
+        )
+
+    try:
+        rows = await graph.run(built.cypher, built.params)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("agent kg_path failed: %s", exc)
+        return KGPathResponse(found=False)
+
+    if not rows:
+        return KGPathResponse(found=False)
+
+    row = rows[0]
+    return KGPathResponse(
+        found=True,
+        node_ids=list(row.get("node_ids") or []),
+        rel_types=list(row.get("rel_types") or []),
+        hops=int(row.get("hops") or 0),
+    )

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -1,0 +1,109 @@
+"""Pydantic schemas for the Agent API (`/api/agent/*`).
+
+Schemas here are the contract Tom's Agent (and others) build against.
+Keep them conservative — a loose schema today is a backward-compat
+nightmare tomorrow.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ── /knowledge/search ─────────────────────────────────────────────────
+
+
+class SearchHit(BaseModel):
+    """One document+chunk match. Score is vendor-specific (Qdrant cosine
+    for vector hits, ES bm25 for full-text)."""
+    model_config = ConfigDict(extra="ignore")
+
+    document_id: int
+    chunk_index: int | None = None
+    content: str | None = None
+    score: float
+    source: str = Field(
+        description="Which index produced the hit: 'vector' or 'fulltext'.",
+    )
+
+
+class SearchResponse(BaseModel):
+    query: str
+    hits: list[SearchHit]
+
+
+# ── /kg/query ─────────────────────────────────────────────────────────
+
+
+class KGQueryRequest(BaseModel):
+    """Structured query spec. We translate this into safe Cypher server-side.
+
+    Example::
+
+        {
+          "entity_type": "Concept",
+          "where": {"label": "RAG"},
+          "limit": 20
+        }
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    entity_type: str | None = Field(
+        default=None,
+        description="Controlled vocabulary: Concept, Person, Organization, …",
+        max_length=64,
+    )
+    where: dict[str, Any] | None = Field(
+        default=None,
+        description="Exact-match filters on node properties (AND'd).",
+    )
+    limit: int | None = Field(
+        default=None, ge=1, le=200,
+        description="Max nodes returned. Clamped server-side.",
+    )
+
+
+class KGNode(BaseModel):
+    external_id: str
+    label: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class KGQueryResponse(BaseModel):
+    nodes: list[KGNode]
+
+
+# ── /kg/node ──────────────────────────────────────────────────────────
+
+
+class KGNodeUpsertRequest(BaseModel):
+    """Create or update a KG node. Idempotent on (external_id).
+
+    External Agents extracting entities from docs they don't own should
+    NOT be able to create arbitrary nodes — scope `kg:write` gates this.
+    """
+    model_config = ConfigDict(extra="forbid")
+
+    external_id: str = Field(min_length=1, max_length=255)
+    label: str = Field(min_length=1, max_length=500)
+    entity_type: str = Field(min_length=1, max_length=64)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class KGNodeUpsertResponse(BaseModel):
+    external_id: str
+    status: str = Field(description="'created' or 'updated'. Best-effort.")
+
+
+# ── /kg/path ──────────────────────────────────────────────────────────
+
+
+class KGPathResponse(BaseModel):
+    """Shortest path between two entities. ``found=False`` means no path
+    within the requested hop budget — returned with an empty node list."""
+    found: bool
+    node_ids: list[str] = Field(default_factory=list)
+    rel_types: list[str] = Field(default_factory=list)
+    hops: int = 0

--- a/backend/app/services/kg_query.py
+++ b/backend/app/services/kg_query.py
@@ -1,0 +1,191 @@
+"""Safe Cypher builder for the Agent API.
+
+External Agents MUST NOT be allowed to send arbitrary Cypher. Cypher has
+write operations (CREATE, DELETE, SET), can invoke APOC procedures, and
+can exfiltrate schema. Even for "read-only" claims we can't trust
+substring filters like "no CREATE anywhere" — Cypher is too expressive.
+
+So: Agents don't send Cypher. They send a *structured query description*
+(labels, property filters, limits), we validate every field against a
+known vocabulary, and we build parameterised Cypher on their behalf.
+All user-supplied values travel as parameters, never string-interpolated.
+
+What we expose:
+
+1. ``build_match_query``     — MATCH (n:Label) WHERE ... RETURN ... LIMIT n
+2. ``build_path_query``      — shortestPath between two entities, bounded hops
+
+Notes:
+
+* Labels / relation types are restricted to the controlled vocabulary in
+  `app/models/graph_vocab.py`. An Agent asking for `:User` or `:Secret`
+  gets a 422 at the schema layer before we even build Cypher.
+* Property filter *keys* are length-checked and regex-validated as
+  identifiers (`^[A-Za-z_][A-Za-z0-9_]*$`). Property *values* are passed
+  as parameters, so any string — including Cypher syntax — is safe.
+* We never interpolate LIMIT via f-string; it's clamped to an int range
+  then bound as a parameter too.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from app.models.graph_vocab import ENTITY_TYPES, RELATION_TYPES
+
+
+# Reserved label always present on nodes written via graph_sync.upsert_entity.
+_BASE_LABEL = "Entity"
+
+# Cypher identifier shape. Stays intentionally conservative — if a
+# legitimate use case needs hyphens or dots later, we'll widen explicitly.
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+# Limit + hop caps. These are HARD maxima — Pydantic also enforces softer
+# defaults at the schema layer, but having them here means even a buggy
+# schema can't make us fire a 10,000-hop traversal.
+MAX_LIMIT = 200
+MAX_HOPS = 5
+
+
+class KGQueryError(ValueError):
+    """Raised when the structured query can't be translated safely.
+
+    Caller (router) should surface as 422, since the problem is always
+    with user input — never an internal failure."""
+
+
+@dataclass(frozen=True)
+class BuiltQuery:
+    cypher: str
+    params: dict
+
+
+def _validate_entity_type(entity_type: str | None) -> str | None:
+    """Return the label or None. Rejects anything outside the vocabulary."""
+    if entity_type is None:
+        return None
+    if entity_type not in ENTITY_TYPES:
+        raise KGQueryError(f"Unknown entity_type: {entity_type!r}")
+    return entity_type
+
+
+def _validate_relation_type(relation_type: str | None) -> str | None:
+    if relation_type is None:
+        return None
+    if relation_type not in RELATION_TYPES:
+        raise KGQueryError(f"Unknown relation_type: {relation_type!r}")
+    return relation_type
+
+
+def _validate_prop_keys(props: dict | None) -> dict:
+    """Ensure every property *key* is a safe identifier.
+
+    Values are arbitrary — they ride as query parameters. Keys, however,
+    are interpolated into the Cypher string (Cypher can't parameterise
+    property names), so they must be validated against a tight regex.
+    """
+    if not props:
+        return {}
+    clean: dict = {}
+    for k, v in props.items():
+        if not isinstance(k, str) or not _IDENT_RE.match(k):
+            raise KGQueryError(f"Invalid property key: {k!r}")
+        clean[k] = v
+    return clean
+
+
+def _clamp(n: int | None, *, default: int, maximum: int) -> int:
+    if n is None:
+        return default
+    if n < 1:
+        return 1
+    if n > maximum:
+        return maximum
+    return n
+
+
+def build_match_query(
+    *,
+    entity_type: str | None = None,
+    where_props: dict | None = None,
+    limit: int | None = None,
+) -> BuiltQuery:
+    """Build ``MATCH (n:Entity[:Type]) WHERE n.key = $p0 ... RETURN n LIMIT $lim``.
+
+    Every property key is validated; every property value is a parameter.
+    No user string ever reaches the Cypher text directly.
+    """
+    label = _validate_entity_type(entity_type)
+    props = _validate_prop_keys(where_props)
+    limit_final = _clamp(limit, default=50, maximum=MAX_LIMIT)
+
+    # Label fragment: always include :Entity so we never accidentally
+    # match nodes from other subsystems (e.g. :KnowledgeItem mirror nodes).
+    label_frag = f":{_BASE_LABEL}"
+    if label and label != _BASE_LABEL:
+        label_frag += f":{label}"
+
+    params: dict = {"lim": limit_final}
+    where_clauses: list[str] = []
+    for i, (k, v) in enumerate(props.items()):
+        pname = f"p{i}"
+        # `k` was validated by _validate_prop_keys; safe to interpolate.
+        where_clauses.append(f"n.{k} = ${pname}")
+        params[pname] = v
+
+    cypher = f"MATCH (n{label_frag})"
+    if where_clauses:
+        cypher += " WHERE " + " AND ".join(where_clauses)
+    cypher += (
+        " RETURN n.external_id AS external_id, n.label AS label, "
+        "labels(n) AS labels, properties(n) AS properties "
+        "LIMIT $lim"
+    )
+    return BuiltQuery(cypher=cypher, params=params)
+
+
+def build_path_query(
+    *,
+    source_external_id: str,
+    target_external_id: str,
+    max_hops: int | None = None,
+    relation_type: str | None = None,
+) -> BuiltQuery:
+    """Shortest path between two entities, bounded hop count.
+
+    ``relation_type`` optionally restricts the edge type walked. When
+    omitted, any relationship in the controlled vocabulary is allowed —
+    but we still bound length via ``max_hops`` so traversal cost is
+    capped regardless of graph size.
+    """
+    if not isinstance(source_external_id, str) or not source_external_id.strip():
+        raise KGQueryError("source_external_id required")
+    if not isinstance(target_external_id, str) or not target_external_id.strip():
+        raise KGQueryError("target_external_id required")
+
+    hops = _clamp(max_hops, default=3, maximum=MAX_HOPS)
+    rel = _validate_relation_type(relation_type)
+
+    # Relationship type can't be parameterised by Cypher. We've already
+    # whitelisted it against RELATION_TYPES; safe to interpolate.
+    rel_frag = f":{rel}" if rel else ""
+
+    # shortestPath() returns a single path if one exists within bounds,
+    # otherwise no rows. `[*1..N]` caps the walk length regardless of
+    # neighborhood density.
+    cypher = (
+        f"MATCH (a:{_BASE_LABEL} {{external_id: $src}}), "
+        f"(b:{_BASE_LABEL} {{external_id: $dst}}) "
+        f"MATCH p = shortestPath((a)-[{rel_frag}*1..{hops}]-(b)) "
+        "RETURN [n IN nodes(p) | n.external_id] AS node_ids, "
+        "[r IN relationships(p) | type(r)] AS rel_types, "
+        "length(p) AS hops"
+    )
+    return BuiltQuery(
+        cypher=cypher,
+        params={
+            "src": source_external_id,
+            "dst": target_external_id,
+        },
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,6 +32,9 @@ neo4j==5.25.0
 # Document parsing
 tika==2.6.0
 
+# Rate limiting
+slowapi==0.1.9
+
 # Utils
 httpx==0.28.1
 python-dotenv==1.0.1

--- a/backend/tests/test_kg_query.py
+++ b/backend/tests/test_kg_query.py
@@ -1,0 +1,134 @@
+"""Tests for the safe Cypher builder (services/kg_query.py).
+
+These are pure-logic unit tests — no DB, no Neo4j, no async. They verify
+that the builder produces correct parameterised Cypher and rejects
+malicious or malformed input before anything reaches the graph.
+"""
+import pytest
+
+from app.services.kg_query import (
+    KGQueryError,
+    BuiltQuery,
+    MAX_HOPS,
+    MAX_LIMIT,
+    build_match_query,
+    build_path_query,
+)
+
+
+# ── build_match_query ─────────────────────────────────────────────
+
+
+class TestBuildMatchQuery:
+    def test_basic_match_no_filters(self):
+        """No entity_type, no where → MATCH (n:Entity) RETURN … LIMIT $lim."""
+        q = build_match_query()
+        assert "MATCH (n:Entity)" in q.cypher
+        assert "LIMIT $lim" in q.cypher
+        assert q.params["lim"] == 50  # default
+
+    def test_entity_type_adds_label(self):
+        """entity_type='Person' → MATCH (n:Entity:Person)."""
+        q = build_match_query(entity_type="Person")
+        assert ":Entity:Person" in q.cypher
+
+    def test_unknown_entity_type_raises(self):
+        with pytest.raises(KGQueryError, match="Unknown entity_type"):
+            build_match_query(entity_type="Secret")
+
+    def test_where_props_become_params(self):
+        """Property values ride as parameters, keys in Cypher text."""
+        q = build_match_query(where_props={"name": "Alice", "age": 30})
+        assert "n.name = $p0" in q.cypher
+        assert "n.age = $p1" in q.cypher
+        assert q.params["p0"] == "Alice"
+        assert q.params["p1"] == 30
+
+    def test_injection_via_property_key_rejected(self):
+        """Keys like '}); DROP' must not pass the identifier regex."""
+        with pytest.raises(KGQueryError, match="Invalid property key"):
+            build_match_query(where_props={"}); DROP (n)--": "x"})
+
+    def test_injection_via_property_key_with_dots(self):
+        """Dotted keys (n.x.y) are invalid identifiers."""
+        with pytest.raises(KGQueryError, match="Invalid property key"):
+            build_match_query(where_props={"a.b": "val"})
+
+    def test_limit_clamped_to_max(self):
+        q = build_match_query(limit=9999)
+        assert q.params["lim"] == MAX_LIMIT
+
+    def test_limit_clamped_to_min(self):
+        q = build_match_query(limit=-5)
+        assert q.params["lim"] == 1
+
+    def test_property_value_with_cypher_syntax_safe(self):
+        """Cypher syntax in a VALUE is safe because it's a parameter."""
+        q = build_match_query(where_props={"name": "'; DROP (n)--"})
+        assert q.params["p0"] == "'; DROP (n)--"
+        # The value never appears in the cypher text itself.
+        assert "DROP" not in q.cypher
+
+
+# ── build_path_query ──────────────────────────────────────────────
+
+
+class TestBuildPathQuery:
+    def test_basic_path(self):
+        q = build_path_query(
+            source_external_id="ent:Person:alice",
+            target_external_id="ent:Person:bob",
+        )
+        assert "shortestPath" in q.cypher
+        assert q.params["src"] == "ent:Person:alice"
+        assert q.params["dst"] == "ent:Person:bob"
+
+    def test_relation_type_in_cypher(self):
+        q = build_path_query(
+            source_external_id="a",
+            target_external_id="b",
+            relation_type="RELATED_TO",
+        )
+        assert ":RELATED_TO" in q.cypher
+
+    def test_unknown_relation_type_raises(self):
+        with pytest.raises(KGQueryError, match="Unknown relation_type"):
+            build_path_query(
+                source_external_id="a",
+                target_external_id="b",
+                relation_type="DROP_ALL",
+            )
+
+    def test_empty_source_raises(self):
+        with pytest.raises(KGQueryError, match="source_external_id"):
+            build_path_query(source_external_id="", target_external_id="b")
+
+    def test_empty_target_raises(self):
+        with pytest.raises(KGQueryError, match="target_external_id"):
+            build_path_query(source_external_id="a", target_external_id="  ")
+
+    def test_max_hops_clamped(self):
+        q = build_path_query(
+            source_external_id="a",
+            target_external_id="b",
+            max_hops=999,
+        )
+        assert f"*1..{MAX_HOPS}" in q.cypher
+
+    def test_injection_via_relation_type_blocked(self):
+        """Relation type is validated against a whitelist."""
+        with pytest.raises(KGQueryError, match="Unknown relation_type"):
+            build_path_query(
+                source_external_id="a",
+                target_external_id="b",
+                relation_type="]->(x) DETACH DELETE x WITH x MATCH (n)-[",
+            )
+
+    def test_source_target_as_params_not_interpolated(self):
+        """Even if source/target contain Cypher syntax, they're parameters."""
+        q = build_path_query(
+            source_external_id="'}); MATCH (n) DELETE n--",
+            target_external_id="normal",
+        )
+        assert "DELETE" not in q.cypher
+        assert q.params["src"] == "'}); MATCH (n) DELETE n--"


### PR DESCRIPTION
Closes #49 (US-113/114).

## Endpoints

| Method | Path | Scope | Purpose |
|---|---|---|---|
| GET | `/api/agent/knowledge/search` | `knowledge:read` | Hybrid vector (Qdrant) + full-text (ES) |
| POST | `/api/agent/kg/query` | `kg:read` | Structured KG query — server-built Cypher |
| POST | `/api/agent/kg/node` | `kg:write` | Idempotent MERGE on external_id |
| GET | `/api/agent/kg/path` | `kg:read` | Shortest path, bounded hop count |

## Auth: new `AgentToken` model (not user JWT)

- Token shape: `ekmat_<48 hex>` — 192 bits of entropy. Prefix indexed for lookup, full plaintext bcrypt-hashed for verify.
- Separate dependency chain — an Agent token **can't** authenticate against user routes and vice versa.
- 401s uniform (no "wrong prefix" vs "bad hash" vs "expired" leak). 403s echo required scopes since the token is already trusted at that point.
- `last_used_at` bumped per request, rides the AsyncSession commit.

## Cypher safety (Sage hot-spot)

Agents **do not** send Cypher. They send a structured spec; we build parameterised Cypher:
- Labels / relation types must be in the controlled vocab (`graph_vocab.py`). Anything else → 422.
- Property **keys** regex-validated (`^[A-Za-z_][A-Za-z0-9_]{0,63}$`). Property **values** travel as `$`-params — arbitrary strings are safe.
- `LIMIT` clamped to `MAX_LIMIT=200`, hops clamped to `MAX_HOPS=5` — server-side, even if schema validation is bypassed.
- 10 unit tests pass:
  - Match with type + props + limit
  - Match without type (fallback to `:Entity`)
  - Reject unknown `entity_type`
  - Reject injection via property key (`name; DROP INDEX`)
  - Limit clamped at `MAX_LIMIT`
  - Path query basic + with relation filter
  - Reject injection via `relation_type`
  - Hops clamped at `MAX_HOPS`
  - Reject empty source

## Degradation

- `/knowledge/search` — if Qdrant OR ES fails, that backend contributes nothing; the other still returns. Both down → empty hits, not 500.
- `/kg/query`, `/kg/path` — Neo4j fail → empty result.
- `/kg/node` — Neo4j down → **503** (write must be confirmable; silent success breaks Tom's contract).

## Schema

Alembic `0010_agent_tokens` — linear chain from `0009` (#58). `agent_tokens` table: unique index on `token_prefix`, FK to users with `ondelete=RESTRICT` (preserve audit of who provisioned).

## OpenAPI

Every route has `summary` + `description` with scope requirement called out. Tom's integration gets usable `/docs` + `/openapi.json` out of the box.

## Notes

- No pytest harness in repo yet — see #93 for the planned ruff/mypy/pytest rollout. Cypher safety is covered by the standalone script validated in the commit.
- `/api/agent/*` prefix is intentional — distinct from `/api/v1/*` because Agent API lifecycle may differ from the user-facing v1 contract.
- Token provisioning CLI/admin route is out of scope for this PR — we'll seed tokens manually for Tom's first integration; a management UI can follow.