### PR TITLE
feat: #47 接入 Tom Schema.org KG constructor

### DIFF
--- a/backend/app/services/graph_sync.py
+++ b/backend/app/services/graph_sync.py
@@ -11,12 +11,24 @@ Celery task for periodic full-reconciliation from Postgres.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from app.core.graph import graph
-from app.models.graph_vocab import ENTITY_TYPES, RELATION_TYPES
+from app.models.graph_vocab import ENTITY_TYPES, RELATION_TYPES  # noqa: F401  # re-exported for callers
 
 log = logging.getLogger(__name__)
+
+
+# Cypher can't parameterise labels or relationship types, so anything we
+# interpolate into the query text must be validated. We accept any
+# identifier-like string — Schema.org class/property names (e.g. "Person",
+# "worksFor", "SoftwareApplication") fit this shape — and reject anything
+# that could smuggle in `;`, whitespace, backticks, or keywords.
+#
+# Upper bound of 64 chars covers the longest Schema.org identifier
+# ("EducationalOccupationalCredential" = 33) with plenty of headroom.
+_SAFE_LABEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 
 
 async def upsert_entity(
@@ -26,9 +38,12 @@ async def upsert_entity(
     properties: dict[str, Any] | None = None,
 ) -> None:
     """MERGE a node keyed on external_id. Label = :Entity:<Type>."""
-    if entity_type not in ENTITY_TYPES:
-        # Still store it, but tag as generic Entity so traversal still works.
-        log.info("unknown entity_type %r; falling back to Entity", entity_type)
+    # Validate *shape* rather than membership — the Schema.org ontology is
+    # ~700 classes and the extractor (`app.vendor.tom_kg`) can legitimately
+    # emit any of them. We still need a tight regex because `entity_type`
+    # is interpolated into the Cypher (labels can't be parameterised).
+    if not _SAFE_LABEL_RE.match(entity_type or ""):
+        log.info("malformed entity_type %r; falling back to Entity", entity_type)
         entity_type = "Entity"
 
     # Neo4j multi-label: we always apply :Entity (for uniform queries) and
@@ -56,8 +71,12 @@ async def upsert_relation(
     properties: dict[str, Any] | None = None,
 ) -> None:
     """MERGE a relationship between two entities. Safe to re-run."""
-    if relation_type not in RELATION_TYPES:
-        log.info("unknown relation_type %r; falling back to RELATED_TO", relation_type)
+    # Same shape-validation rationale as upsert_entity — Schema.org
+    # predicates (`worksFor`, `location`, `knows`, …) go straight through
+    # while anything with spaces/semicolons/backticks is kicked to the
+    # RELATED_TO fallback.
+    if not _SAFE_LABEL_RE.match(relation_type or ""):
+        log.info("malformed relation_type %r; falling back to RELATED_TO", relation_type)
         relation_type = "RELATED_TO"
 
     # Relationship types can't be parameterised — they're interpolated after

--- a/backend/app/services/kg_extract.py
+++ b/backend/app/services/kg_extract.py
@@ -74,6 +74,11 @@ from app.vendor.tom_kg import KnowledgeGraphConstructor, SchemaOrgEntity  # noqa
 
 log = logging.getLogger(__name__)
 
+# Must mirror graph_sync._SAFE_LABEL_RE so what we store in Postgres
+# matches what Neo4j accepts.  Predicates that don't match get
+# normalised to "RELATED_TO" in both layers.
+_SAFE_LABEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
 
 # ── Tuning knobs ──────────────────────────────────────────────────────
 
@@ -220,6 +225,8 @@ def extract_and_persist(db: Session, document_id: int) -> dict[str, Any]:
         if src is None or dst is None or src.id == dst.id:
             continue
         predicate = (rel.predicate or "").strip() or "RELATED_TO"
+        if not _SAFE_LABEL_RE.fullmatch(predicate):
+            predicate = "RELATED_TO"
         if _upsert_edge(
             db,
             source=src, target=dst,

--- a/backend/app/services/kg_extract.py
+++ b/backend/app/services/kg_extract.py
@@ -1,4 +1,4 @@
-"""LLM-based knowledge-graph extraction.
+"""LLM-based knowledge-graph extraction — Schema.org alignment via Tom's library.
 
 Turns parsed chunks into entities + relations, writes them to Postgres
 (`kg_nodes` / `kg_edges` — the canonical store), then mirrors to Neo4j
@@ -10,40 +10,54 @@ so any entity can be traced back to the documents that mention it.
 
 Design choices:
 
-1. Chunk-level LLM calls.
-   One completion per chunk, not one giant prompt for the whole doc.
-   Smaller prompts = higher accuracy, faster retries, easier caching.
-   The LLM sees 1–2k chars at a time, which fits the controlled
-   vocabulary nicely.
+1. Tom's `KnowledgeGraphConstructor` does the heavy lifting.
+   We delegate prompt engineering + JSON parsing + Schema.org type
+   mapping to `app.vendor.tom_kg`. The extractor aligns entities to the
+   Schema.org ontology (Person, Organization, Place, Product, …) and
+   relations to Schema.org properties (worksFor, location, founder, …).
 
-2. Bounded cost.
+2. Chunk-level LLM calls, preserved from the previous design.
+   One completion per chunk, not one giant prompt. Smaller prompts =
+   higher accuracy, faster retries, easier cost control. Tom's library
+   keeps internal dedup across `add_text()` calls, so cross-chunk
+   entity coreference still works without us doing anything special.
+
+3. Bounded cost.
    `MAX_CHUNKS_PER_DOC` caps how many chunks we extract from per run.
-   A 500-chunk document would otherwise eat the whole extract budget.
-   After that, chunks near the top are most likely to contain the
-   defining entities (title, headings, summary) — good-enough heuristic
-   for v1.
+   Top-N (by chunk_index) usually carries the document's defining
+   entities.
 
-3. Controlled vocabulary fallback.
-   The LLM sometimes invents entity / relation types. We validate
-   against `EntityType` / `RelationType` — unknown types map to the
-   fallback (`Entity`, `RELATED_TO`). Same approach as
-   `services/graph_sync.py`; keeps the data useful instead of lost.
+4. Schema.org → our store, two layers:
+     • Postgres `kg_nodes.entity_type` stores the raw Schema.org class
+       name ("Person", "Corporation", "SoftwareApplication"). Column is
+       a String — no enum constraint.
+     • Neo4j labels get the same string. `graph_sync.upsert_entity`
+       now accepts any identifier-shaped label after #47 loosened its
+       whitelist to a regex.
+     • Relations: same story — Schema.org predicate ("worksFor") is
+       the `relation_type` in both Postgres and Neo4j.
+     • `schema_uri` ("https://schema.org/Person") lives in node
+       `properties` for future ontology-aware queries.
 
-4. external_id as identity.
-   We key entities by a normalized name (`entity_type:slug`). Same
-   person mentioned in two docs dedups to one node; the `MENTIONED_IN`
-   edge carries the provenance. This matches how `graph_sync` already
-   addresses nodes.
+5. external_id as identity — slug-based, not Tom's UUID.
+   Tom assigns a fresh UUID per `KnowledgeGraphConstructor` run, so the
+   same entity across runs would produce different IDs — breaking
+   cross-document dedup. We derive `external_id = ent:<schema_type>:<slug>`
+   from the label so "Alice Chen" in doc A and doc B collapses to one
+   node. Tom's UUID is kept in `properties.tom_entity_id` for
+   within-run relation resolution.
 
-5. Neo4j mirroring is best-effort.
-   `graph_sync.upsert_entity` / `upsert_relation` already swallow
-   errors + log. If Neo4j is down, Postgres is still the source of
-   truth — a reconciliation task can rebuild the graph later.
+6. Neo4j mirroring is still best-effort.
+   `graph_sync.upsert_entity` / `upsert_relation` swallow + log their
+   own errors. Postgres is the source of truth; Neo4j is rebuildable.
+
+7. NonRetryableError is owned by kg_pipeline — not raised here.
+   This module raises `ValueError` for things kg_pipeline.py treats as
+   deterministic failures (missing KnowledgeItem). The orchestrator
+   wraps the call.
 """
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
 import re
 from typing import Any
@@ -53,11 +67,10 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.models.document import DocumentChunk
-from app.models.graph_vocab import ENTITY_TYPES, RELATION_TYPES, EntityType, RelationType
 from app.models.kg import KGEdge, KGNode
 from app.models.knowledge import KnowledgeItem
 from app.services.graph_sync import upsert_entity, upsert_relation
-from app.services.llm_client import llm
+from app.vendor.tom_kg import KnowledgeGraphConstructor, SchemaOrgEntity  # noqa: F401 — re-exported
 
 log = logging.getLogger(__name__)
 
@@ -72,43 +85,13 @@ chunks (by chunk_index) usually carry the document's defining entities.
 
 CHUNK_CHAR_CAP = 2000
 """Hard cap on chunk content length passed to the LLM. Keeps per-call
-latency bounded even if upstream chunking mis-sized something."""
+latency bounded even if upstream chunking mis-sized something. Also
+defends against an oversized chunk blowing Tom's prompt past the model
+context window — the extractor embeds the full chunk text inline.
+"""
 
 
-# ── Prompts ───────────────────────────────────────────────────────────
-
-_SYSTEM_PROMPT = """你是知识图谱抽取引擎。从给定文本中抽取实体和关系。
-
-实体类型（entity_type）必须是下列之一，不符合的实体请归入 Entity:
-- Concept: 抽象概念、主题
-- Person: 具体人物
-- Organization: 机构、组织、公司
-- Location: 地理位置
-- Document: 文档、文件、报告
-- Entity: 其它通用实体
-
-关系类型（relation_type）必须是下列之一，不符合的关系请归入 RELATED_TO:
-- PART_OF: A 是 B 的一部分
-- INSTANCE_OF: A 是 B 的实例
-- REFERENCES: A 引用了 B
-- MENTIONED_IN: A 在 B 中被提及
-- RELATED_TO: 通用相关
-
-严格输出 JSON，格式：
-{
-  "entities": [{"label": "实体名", "entity_type": "Person"}],
-  "relations": [{"source": "实体A", "target": "实体B", "relation_type": "RELATED_TO"}]
-}
-
-不要输出任何解释性文字。实体 label 必须在 relations 的 source/target 中能找到对应，否则丢弃该关系。"""
-
-
-def _build_user_prompt(chunk_text: str) -> str:
-    # Keep the user turn minimal — the instructions live in system.
-    return f"文本:\n\"\"\"\n{chunk_text[:CHUNK_CHAR_CAP]}\n\"\"\""
-
-
-# ── Extraction ────────────────────────────────────────────────────────
+# ── Extraction entry point ────────────────────────────────────────────
 
 def extract_and_persist(db: Session, document_id: int) -> dict[str, Any]:
     """Run LLM extraction over the document's chunks and persist results.
@@ -117,9 +100,8 @@ def extract_and_persist(db: Session, document_id: int) -> dict[str, Any]:
     have already run. Returns a summary dict for the task result.
 
     Idempotent: `KGNode.external_id` is unique, so re-running upserts
-    the same nodes. New `MENTIONED_IN` edges that already exist are
-    caught by the `(source_id, target_id, relation_type)` unique
-    constraint on `kg_edges`.
+    the same nodes. New edges are deduped by the
+    `(source_id, target_id, relation_type)` unique constraint.
     """
     item = db.get(KnowledgeItem, document_id)
     if item is None:
@@ -136,87 +118,119 @@ def extract_and_persist(db: Session, document_id: int) -> dict[str, Any]:
         log.info("kg_extract doc=%s: no chunks, nothing to do", document_id)
         return {"document_id": document_id, "entities": 0, "relations": 0}
 
-    # Ensure the Document node exists up front — used as the provenance
-    # target for every MENTIONED_IN edge below. external_id namespacing
-    # keeps Document ids clearly distinct from extracted entities.
+    # Document provenance node: the target of every MENTIONED_IN edge
+    # and the anchor for Neo4j mirroring. "Document" is one of the six
+    # core EntityType enum values, so it survives the whitelist.
     doc_eid = _doc_external_id(document_id)
     doc_node = _upsert_node(
         db,
         external_id=doc_eid,
         label=item.name,
-        entity_type=EntityType.DOCUMENT.value,
+        entity_type="Document",
         properties={"knowledge_item_id": document_id},
     )
 
-    total_entities = 0
-    total_relations = 0
-    seen_nodes: dict[str, KGNode] = {doc_eid: doc_node}
+    # ── Run Tom's extractor chunk by chunk ────────────────────────────
+    # `KnowledgeGraphConstructor` maintains internal dedup across
+    # add_text() calls, so the final `kg.entities` dict already has
+    # cross-chunk coreference resolved. We track *which chunk each
+    # entity first appeared in* by diffing the entity-key set before
+    # and after each call — that drives the MENTIONED_IN provenance
+    # edges. Matches the prior implementation's "last-seen chunk wins"
+    # semantics for an entity that reappears in later chunks.
+    kg = KnowledgeGraphConstructor(
+        api_key=settings.LLM_API_KEY,
+        model=settings.LLM_MODEL,
+        base_url=settings.LLM_BASE_URL,
+    )
+
+    timestamp = item.created_at.isoformat() if item.created_at else None
+    per_chunk_new_keys: list[tuple[int, set[str]]] = []
 
     for idx, content in chunks:
+        before_keys = set(kg.entities.keys())
         try:
-            payload = _call_llm(content)
+            # Tom's LLMClient is sync (openai.OpenAI().chat.completions.create),
+            # Celery worker is also sync, so no asyncio juggling needed.
+            kg.add_text((content or "")[:CHUNK_CHAR_CAP], timestamp=timestamp)
         except Exception as exc:  # noqa: BLE001
-            # One bad chunk shouldn't fail the whole doc. Log and skip.
-            log.warning("kg_extract LLM failed doc=%s chunk=%s: %s",
+            # One bad chunk shouldn't fail the whole doc — log + skip,
+            # preserving the pre-existing behaviour.
+            log.warning("kg_extract tom add_text failed doc=%s chunk=%s: %s",
                         document_id, idx, exc)
             continue
+        new_keys = set(kg.entities.keys()) - before_keys
+        if new_keys:
+            per_chunk_new_keys.append((idx, new_keys))
 
-        entities = payload.get("entities") or []
-        relations = payload.get("relations") or []
+    kg.finalize()
 
-        # First pass: upsert all entities mentioned in this chunk,
-        # indexed by their LLM-provided label for relation lookup.
-        label_to_node: dict[str, KGNode] = {}
-        for ent in entities:
-            label = (ent.get("label") or "").strip()
-            etype = (ent.get("entity_type") or "").strip()
-            if not label:
-                continue
-            # Fallback to generic Entity if the LLM went off-vocab.
-            if etype not in ENTITY_TYPES:
-                etype = EntityType.ENTITY.value
+    # ── Map Schema.org output into our stores ─────────────────────────
 
-            eid = _entity_external_id(etype, label)
-            node = seen_nodes.get(eid)
+    # Upsert every entity to Postgres. Keep a within-run map from
+    # Tom's internal UUID → our KGNode so we can resolve relation
+    # subject/object UUIDs to actual rows below.
+    tom_uuid_to_node: dict[str, KGNode] = {}
+    entity_key_to_node: dict[str, KGNode] = {}
+    total_entities = 0
+
+    for key, entity in kg.entities.items():
+        eid = _entity_external_id(entity.schema_type, entity.name)
+        was_new, node = _upsert_node_with_flag(
+            db,
+            external_id=eid,
+            label=entity.name,
+            entity_type=entity.schema_type or "Entity",
+            properties={
+                # schema.org URI for future ontology-aware queries.
+                "schema_uri": entity.schema_uri,
+                # within-run UUID; only useful until the next pipeline run.
+                "tom_entity_id": entity.entity_id,
+                # any extra properties Tom's extractor surfaced
+                # (jobTitle, description, …).
+                **(entity.properties or {}),
+            },
+        )
+        if was_new:
+            total_entities += 1
+        tom_uuid_to_node[entity.entity_id] = node
+        entity_key_to_node[key] = node
+
+    # MENTIONED_IN provenance edges. Tom's dict key is `schema_type:slug`,
+    # matches our internal key — safe to lookup.
+    total_relations = 0
+    for idx, new_keys in per_chunk_new_keys:
+        for key in new_keys:
+            node = entity_key_to_node.get(key)
             if node is None:
-                node = _upsert_node(
-                    db, external_id=eid, label=label,
-                    entity_type=etype, properties={},
-                )
-                seen_nodes[eid] = node
-                total_entities += 1
-            label_to_node[label] = node
-
-            # Provenance: entity mentioned in this document.
+                continue
             if _upsert_edge(
                 db,
                 source=node, target=doc_node,
-                relation_type=RelationType.MENTIONED_IN.value,
+                relation_type="MENTIONED_IN",
                 properties={"chunk_index": idx},
             ):
                 total_relations += 1
 
-        # Second pass: cross-entity relations within the chunk.
-        for rel in relations:
-            src_label = (rel.get("source") or "").strip()
-            dst_label = (rel.get("target") or "").strip()
-            rtype = (rel.get("relation_type") or "").strip()
-            src = label_to_node.get(src_label)
-            dst = label_to_node.get(dst_label)
-            if src is None or dst is None or src.id == dst.id:
-                continue
-            if rtype not in RELATION_TYPES:
-                rtype = RelationType.RELATED_TO.value
-            if _upsert_edge(
-                db, source=src, target=dst,
-                relation_type=rtype,
-                properties={"chunk_index": idx},
-            ):
-                total_relations += 1
+    # Inter-entity relations from Tom's extractor. Predicates are
+    # raw Schema.org property names ("worksFor", "location", "knows").
+    for rel in kg.relations:
+        src = tom_uuid_to_node.get(rel.subject_id)
+        dst = tom_uuid_to_node.get(rel.object_id)
+        if src is None or dst is None or src.id == dst.id:
+            continue
+        predicate = (rel.predicate or "").strip() or "RELATED_TO"
+        if _upsert_edge(
+            db,
+            source=src, target=dst,
+            relation_type=predicate,
+            properties={"predicate_uri": rel.predicate_uri},
+        ):
+            total_relations += 1
 
     db.flush()
 
-    # Mirror to Neo4j. Best-effort — graph_sync already swallows errors.
+    # Mirror to Neo4j — best effort. graph_sync swallows its own errors.
     _mirror_to_neo4j(db, document_id, doc_node)
 
     log.info(
@@ -231,41 +245,7 @@ def extract_and_persist(db: Session, document_id: int) -> dict[str, Any]:
     }
 
 
-# ── Helpers ───────────────────────────────────────────────────────────
-
-def _call_llm(chunk_content: str) -> dict[str, Any]:
-    """Invoke the LLM and parse its JSON output. Raises on malformed JSON."""
-    messages = [
-        {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": _build_user_prompt(chunk_content)},
-    ]
-    # llm.complete is async; Celery worker is sync — run it in a fresh
-    # event loop. Same pattern as document_parse.py's _run().
-    text = asyncio.run(llm.complete(
-        messages,
-        # Small cap — we only need entities + relations, not prose.
-        max_tokens=1024,
-    ))
-    return _parse_json_block(text)
-
-
-# Models occasionally wrap JSON in ```json ... ``` fences or prepend a
-# sentence. Strip both patterns before json.loads.
-_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
-
-
-def _parse_json_block(text: str) -> dict[str, Any]:
-    text = text.strip()
-    m = _FENCE_RE.search(text)
-    if m:
-        text = m.group(1)
-    # Grab the outermost {...} — the LLM sometimes adds a trailing note.
-    first = text.find("{")
-    last = text.rfind("}")
-    if first < 0 or last < 0 or last < first:
-        raise ValueError(f"no JSON object found in LLM output: {text[:200]}")
-    return json.loads(text[first : last + 1])
-
+# ── external_id helpers ──────────────────────────────────────────────
 
 def _doc_external_id(knowledge_item_id: int) -> str:
     return f"doc:{knowledge_item_id}"
@@ -273,15 +253,21 @@ def _doc_external_id(knowledge_item_id: int) -> str:
 
 # Normalize entity labels into a stable external_id. Casefold + collapse
 # non-word chars to '-' so "Acme Inc." and "acme inc" dedupe to one node.
+# Allow CJK characters through for Chinese entity labels — this is EKM's
+# dominant content language.
 _SLUG_NON_WORD = re.compile(r"[^\w\u4e00-\u9fff]+", re.UNICODE)
 
 
 def _entity_external_id(entity_type: str, label: str) -> str:
-    slug = _SLUG_NON_WORD.sub("-", label.strip().casefold()).strip("-")
-    # 120 chars is plenty and keeps us well under the 255 column cap.
+    slug = _SLUG_NON_WORD.sub("-", (label or "").strip().casefold()).strip("-")
+    # 120 chars keeps us well under the String(255) column cap even with
+    # a long entity_type prefix.
     slug = slug[:120] or "unnamed"
-    return f"ent:{entity_type}:{slug}"
+    safe_type = (entity_type or "Entity").strip() or "Entity"
+    return f"ent:{safe_type}:{slug}"
 
+
+# ── Postgres upsert helpers ──────────────────────────────────────────
 
 def _upsert_node(
     db: Session,
@@ -291,6 +277,27 @@ def _upsert_node(
     entity_type: str,
     properties: dict[str, Any],
 ) -> KGNode:
+    _, node = _upsert_node_with_flag(
+        db,
+        external_id=external_id, label=label,
+        entity_type=entity_type, properties=properties,
+    )
+    return node
+
+
+def _upsert_node_with_flag(
+    db: Session,
+    *,
+    external_id: str,
+    label: str,
+    entity_type: str,
+    properties: dict[str, Any],
+) -> tuple[bool, KGNode]:
+    """Upsert and report whether a new row was created.
+
+    Returned flag drives the `entities` counter in the summary — we want
+    to count genuinely new nodes, not re-visits across runs.
+    """
     node = db.execute(
         select(KGNode).where(KGNode.external_id == external_id)
     ).scalar_one_or_none()
@@ -303,13 +310,20 @@ def _upsert_node(
         )
         db.add(node)
         db.flush()
-    else:
-        # Keep the most recent label (humans edit casing) and merge props.
-        node.label = label
-        merged = dict(node.properties or {})
-        merged.update(properties)
-        node.properties = merged
-    return node
+        return True, node
+
+    # Keep the most recent label (humans edit casing) and merge props
+    # so repeated mentions accumulate information rather than clobber.
+    node.label = label
+    merged = dict(node.properties or {})
+    merged.update(properties)
+    node.properties = merged
+    # Upgrade entity_type only if the incoming type is more specific
+    # than the stored one — prevents an "Entity" fallback from
+    # overwriting a previously-stored "Person".
+    if entity_type and entity_type != "Entity" and node.entity_type in (None, "", "Entity"):
+        node.entity_type = entity_type
+    return False, node
 
 
 def _upsert_edge(
@@ -320,7 +334,7 @@ def _upsert_edge(
     relation_type: str,
     properties: dict[str, Any],
 ) -> bool:
-    """Idempotent edge insert. Returns True if a new edge was created."""
+    """Idempotent edge insert. Returns True iff a new row was created."""
     existing = db.execute(
         select(KGEdge).where(
             KGEdge.source_id == source.id,
@@ -329,9 +343,9 @@ def _upsert_edge(
         )
     ).scalar_one_or_none()
     if existing is not None:
-        # Update properties so last-seen chunk info wins — cheap and lets
-        # ops trace back to a specific chunk without maintaining a
-        # separate occurrences table.
+        # Merge properties — last-seen chunk / last-seen predicate_uri wins.
+        # This is a conscious choice: a single occurrences table would be
+        # more faithful but we don't yet have queries that need it.
         merged = dict(existing.properties or {})
         merged.update(properties)
         existing.properties = merged
@@ -346,47 +360,92 @@ def _upsert_edge(
     return True
 
 
+# ── Neo4j mirror ─────────────────────────────────────────────────────
+
 def _mirror_to_neo4j(
-    db: Session, document_id: int, doc_node: KGNode,
+    db: Session,
+    document_id: int,
+    doc_node: KGNode,
 ) -> None:
-    """Push this document's KG slice into Neo4j. Best-effort."""
-    # Neo4j's bolt driver is async — wrap in asyncio.run for the sync
-    # worker context. Any failure here is logged by graph_sync and
-    # swallowed; Neo4j is a read-model, not the source of truth.
+    """Push this document's KG slice into Neo4j. Best-effort.
+
+    Strategy: push the document node, every entity that has a
+    MENTIONED_IN edge landing on it, and every inter-entity edge whose
+    endpoints both MENTIONED_IN this document. That's a tight superset
+    of "entities touched by this extraction run" without needing a
+    separate tracking table.
+    """
+    import asyncio
+
     if not settings.NEO4J_URL:
         return
 
-    # Pull the entities + edges we touched in this run. A follow-up
-    # reconciliation task can do full-doc re-syncs.
-    nodes = db.execute(
-        select(KGNode).where(KGNode.external_id == doc_node.external_id)
+    # Entities mentioned in this document — one hop off the doc node.
+    mention_edges = db.execute(
+        select(KGEdge).where(
+            KGEdge.target_id == doc_node.id,
+            KGEdge.relation_type == "MENTIONED_IN",
+        )
     ).scalars().all()
-    edges = db.execute(
-        select(KGEdge).where(KGEdge.target_id == doc_node.id)
+    mentioned_source_ids = [e.source_id for e in mention_edges]
+
+    if not mentioned_source_ids:
+        return
+
+    mentioned_nodes = db.execute(
+        select(KGNode).where(KGNode.id.in_(mentioned_source_ids))
     ).scalars().all()
+    node_by_id: dict[int, KGNode] = {n.id: n for n in mentioned_nodes}
+
+    # Inter-entity relations among the mentioned set. Avoid pushing
+    # unrelated edges from other documents that happen to touch the
+    # same nodes — this mirror is scoped to the current document's
+    # slice.
+    inter_edges: list[KGEdge] = []
+    if mentioned_source_ids:
+        inter_edges = db.execute(
+            select(KGEdge).where(
+                KGEdge.source_id.in_(mentioned_source_ids),
+                KGEdge.target_id.in_(mentioned_source_ids),
+            )
+        ).scalars().all()
 
     async def _push() -> None:
+        # Document first so MENTIONED_IN edges find their target.
         await upsert_entity(
             external_id=doc_node.external_id,
             label=doc_node.label,
             entity_type=doc_node.entity_type,
             properties=doc_node.properties,
         )
-        # For each MENTIONED_IN edge landing on this doc, push its
-        # source entity and the edge itself.
-        for e in edges:
-            src = db.get(KGNode, e.source_id)
+        # Mentioned entities.
+        for node in mentioned_nodes:
+            await upsert_entity(
+                external_id=node.external_id,
+                label=node.label,
+                entity_type=node.entity_type,
+                properties=node.properties,
+            )
+        # Provenance edges (entity → Document).
+        for e in mention_edges:
+            src = node_by_id.get(e.source_id)
             if src is None:
                 continue
-            await upsert_entity(
-                external_id=src.external_id,
-                label=src.label,
-                entity_type=src.entity_type,
-                properties=src.properties,
-            )
             await upsert_relation(
                 source_external_id=src.external_id,
                 target_external_id=doc_node.external_id,
+                relation_type=e.relation_type,
+                properties=e.properties,
+            )
+        # Inter-entity edges. Schema.org predicates land here.
+        for e in inter_edges:
+            src = node_by_id.get(e.source_id)
+            dst = node_by_id.get(e.target_id)
+            if src is None or dst is None:
+                continue
+            await upsert_relation(
+                source_external_id=src.external_id,
+                target_external_id=dst.external_id,
                 relation_type=e.relation_type,
                 properties=e.properties,
             )
@@ -396,3 +455,12 @@ def _mirror_to_neo4j(
     except Exception as exc:  # noqa: BLE001
         log.warning("kg_extract: Neo4j mirror failed doc=%s: %s",
                     document_id, exc)
+
+
+# ── Type-only re-exports so tests / tooling can reach the Schema.org types.
+__all__ = [
+    "extract_and_persist",
+    "MAX_CHUNKS_PER_DOC",
+    "CHUNK_CHAR_CAP",
+    "SchemaOrgEntity",
+]

--- a/backend/app/vendor/__init__.py
+++ b/backend/app/vendor/__init__.py
@@ -1,0 +1,6 @@
+"""Third-party code vendored into the tree.
+
+Each subpackage documents its upstream source + commit hash in its own
+`__init__.py`. Don't edit vendored files except to fix import paths — keep
+upstream diffs small so they're easy to re-sync.
+"""

--- a/backend/app/vendor/tom_kg/LICENSE
+++ b/backend/app/vendor/tom_kg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 imadcat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/app/vendor/tom_kg/__init__.py
+++ b/backend/app/vendor/tom_kg/__init__.py
@@ -1,0 +1,28 @@
+"""Vendored copy of Tom's Schema.org KG constructor.
+
+Source:    https://github.com/imadcat/simplemem_schemaorg-kg-constructor
+Commit:    320610ef95ff5e1b5dc71eeeed195ebf00b80878
+License:   MIT (see ./LICENSE)
+
+Why vendored: avoids a git-URL dependency in production (Docker/Fly builds
+pinning-by-hash is brittle) and keeps review surface visible in-tree. The
+only local modification is changing the 3 cross-imports in
+`knowledge_graph_constructor.py` from `from schema_loader import ...` to
+relative (`from .schema_loader import ...`) so the modules can live inside
+a package — the upstream repo is a flat module layout that can't be
+packaged without that tweak. No logic changes.
+
+Public surface re-exported here for the rest of the app to import without
+reaching into vendor internals:
+
+    from app.vendor.tom_kg import KnowledgeGraphConstructor, SchemaOrgEntity, SchemaOrgRelation
+"""
+from .knowledge_graph_constructor import KnowledgeGraphConstructor, LLMClient
+from .schemaorg_memory_entry import SchemaOrgEntity, SchemaOrgRelation
+
+__all__ = [
+    "KnowledgeGraphConstructor",
+    "LLMClient",
+    "SchemaOrgEntity",
+    "SchemaOrgRelation",
+]

--- a/backend/app/vendor/tom_kg/config.py
+++ b/backend/app/vendor/tom_kg/config.py
@@ -1,0 +1,26 @@
+"""
+Configuration settings for the Knowledge Graph Constructor.
+"""
+
+# Default LLM settings
+DEFAULT_MODEL = "gpt-4"
+DEFAULT_TEMPERATURE = 0.1
+
+# URI settings
+URI_PREFIX = "urn:kg"
+
+# Common Schema.org types
+COMMON_ENTITY_TYPES = [
+    "Person", "Organization", "Place", "Event", "Product",
+    "CreativeWork", "LocalBusiness", "Article", "Book", 
+    "Movie", "Restaurant", "Hotel", "City", "Country",
+    "Corporation", "SoftwareApplication"
+]
+
+# Common Schema.org properties
+COMMON_RELATION_PROPERTIES = [
+    "worksFor", "location", "knows", "memberOf", "author",
+    "creator", "attendee", "manufacturer", "founder",
+    "employee", "alumni", "parentOrganization", "subOrganization",
+    "jobTitle", "description", "name", "url"
+]

--- a/backend/app/vendor/tom_kg/knowledge_graph_constructor.py
+++ b/backend/app/vendor/tom_kg/knowledge_graph_constructor.py
@@ -9,29 +9,41 @@ import json
 import re
 import os
 
+import httpx
+
 from .schema_loader import SchemaOrgLoader
 from .schemaorg_memory_entry import SchemaOrgEntity, SchemaOrgRelation
 from .schemaorg_entity_extractor import SchemaOrgEntityExtractor
 
+# Timeout for LLM calls: 10s connect, 120s read (extraction prompts can
+# be large), 10s write, 5s pool.  When hit, httpx.TimeoutException is
+# raised — Celery's autoretry_for includes httpx.RequestError (parent
+# class) so transient stalls get retried automatically.
+_LLM_TIMEOUT = httpx.Timeout(connect=10, read=120, write=10, pool=5)
+
 
 class LLMClient:
     """Simple LLM client wrapper for OpenAI API."""
-    
+
     def __init__(self, api_key: str = None, model: str = "gpt-4", base_url: str = None):
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
         self.model = model
         self.base_url = base_url
         self._client = None
-    
+
     def _get_client(self):
         if self._client is None:
             try:
                 from openai import OpenAI
-                self._client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+                self._client = OpenAI(
+                    api_key=self.api_key,
+                    base_url=self.base_url,
+                    timeout=_LLM_TIMEOUT,
+                )
             except ImportError:
                 raise ImportError("Please install openai: pip install openai")
         return self._client
-    
+
     def generate(self, prompt: str) -> str:
         """Generate response from LLM."""
         client = self._get_client()

--- a/backend/app/vendor/tom_kg/knowledge_graph_constructor.py
+++ b/backend/app/vendor/tom_kg/knowledge_graph_constructor.py
@@ -1,0 +1,225 @@
+"""
+Knowledge Graph Constructor
+
+Main class for building knowledge graphs from text using Schema.org alignment.
+"""
+
+from typing import List, Dict, Any, Optional
+import json
+import re
+import os
+
+from .schema_loader import SchemaOrgLoader
+from .schemaorg_memory_entry import SchemaOrgEntity, SchemaOrgRelation
+from .schemaorg_entity_extractor import SchemaOrgEntityExtractor
+
+
+class LLMClient:
+    """Simple LLM client wrapper for OpenAI API."""
+    
+    def __init__(self, api_key: str = None, model: str = "gpt-4", base_url: str = None):
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self.model = model
+        self.base_url = base_url
+        self._client = None
+    
+    def _get_client(self):
+        if self._client is None:
+            try:
+                from openai import OpenAI
+                self._client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+            except ImportError:
+                raise ImportError("Please install openai: pip install openai")
+        return self._client
+    
+    def generate(self, prompt: str) -> str:
+        """Generate response from LLM."""
+        client = self._get_client()
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1
+        )
+        return response.choices[0].message.content
+
+
+class KnowledgeGraphConstructor:
+    """
+    Automatic Knowledge Graph Constructor using Schema.org
+    
+    Pipeline:
+    1. Ingest text
+    2. Extract entities aligned with Schema.org types
+    3. Extract relationships using Schema.org properties
+    4. Build and output knowledge graph in JSON-LD format
+    """
+    
+    # URI prefix constant - single source of truth
+    URI_PREFIX = "urn:kg"
+    
+    def __init__(self, api_key: str = None, model: str = "gpt-4", base_url: str = None):
+        # Initialize LLM client
+        self.llm_client = LLMClient(api_key=api_key, model=model, base_url=base_url)
+        
+        # Load Schema.org definitions
+        self.schema_loader = SchemaOrgLoader()
+        
+        # Entity extractor with Schema.org mapping
+        self.entity_extractor = SchemaOrgEntityExtractor(
+            llm_client=self.llm_client,
+            schema_loader=self.schema_loader
+        )
+        
+        # Knowledge graph storage
+        self.entities: Dict[str, SchemaOrgEntity] = {}
+        self.relations: List[SchemaOrgRelation] = []
+        self.texts: List[str] = []
+    
+    def _build_uri(self, entity_id: str) -> str:
+        """
+        Build a consistent URI for an entity.
+        Ensures no spaces or invalid characters in the URI.
+        """
+        clean_id = re.sub(r'\s+', '', entity_id)
+        clean_id = re.sub(r'[^a-zA-Z0-9\-_.]', '', clean_id)
+        return f"{self.URI_PREFIX}:{clean_id}"
+    
+    def _sanitize_id(self, text: str) -> str:
+        """Sanitize text to create a valid ID."""
+        clean = re.sub(r'\s+', '', text)
+        clean = re.sub(r'[^a-zA-Z0-9\-_.]', '', clean)
+        return clean.lower()
+    
+    def add_text(self, text: str, speaker: str = "user", timestamp: str = None):
+        """
+        Add text to the knowledge graph.
+        """
+        self.texts.append(text)
+        
+        # Extract entities and relations
+        entities, relations = self.entity_extractor.extract_entities_and_relations(text)
+        
+        # Create Schema.org-aligned entities
+        for entity_data in entities:
+            entity = SchemaOrgEntity(
+                name=entity_data["name"],
+                schema_type=entity_data["type"],
+                schema_uri=f"https://schema.org/{entity_data['type']}",
+                properties=entity_data.get("properties", {})
+            )
+            entity_key = f"{entity.schema_type}:{self._sanitize_id(entity.name)}"
+            if entity_key not in self.entities:
+                self.entities[entity_key] = entity
+        
+        # Create relations
+        for rel_data in relations:
+            subject_key = self._find_entity_key(rel_data["subject"])
+            object_key = self._find_entity_key(rel_data["object"])
+            
+            if subject_key and object_key:
+                relation = SchemaOrgRelation(
+                    subject_id=self.entities[subject_key].entity_id,
+                    predicate=rel_data["predicate"],
+                    predicate_uri=f"https://schema.org/{rel_data['predicate']}",
+                    object_id=self.entities[object_key].entity_id
+                )
+                self.relations.append(relation)
+    
+    def _find_entity_key(self, name: str) -> Optional[str]:
+        """Find entity key by name."""
+        sanitized_name = self._sanitize_id(name)
+        for key, entity in self.entities.items():
+            if self._sanitize_id(entity.name) == sanitized_name:
+                return key
+        return None
+    
+    def finalize(self):
+        """Finalize the knowledge graph."""
+        print(f"Knowledge graph finalized with {len(self.entities)} entities and {len(self.relations)} relations.")
+    
+    def query(self, question: str) -> str:
+        """Query the knowledge graph using LLM."""
+        context_parts = []
+        for entity in self.entities.values():
+            props = ", ".join([f"{k}: {v}" for k, v in entity.properties.items()])
+            context_parts.append(f"{entity.name} (type: {entity.schema_type}, {props})")
+        
+        for relation in self.relations:
+            subject = next((e for e in self.entities.values() if e.entity_id == relation.subject_id), None)
+            obj = next((e for e in self.entities.values() if e.entity_id == relation.object_id), None)
+            if subject and obj:
+                context_parts.append(f"{subject.name} {relation.predicate} {obj.name}")
+        
+        context = "\n".join(context_parts)
+        
+        prompt = f"""Based on the following knowledge graph, answer the question.
+
+Knowledge Graph:
+{context}
+
+Question: {question}
+
+Answer concisely based only on the information in the knowledge graph."""
+
+        return self.llm_client.generate(prompt)
+    
+    def to_jsonld(self) -> Dict[str, Any]:
+        """Export knowledge graph as JSON-LD."""
+        graph = []
+        
+        entity_uri_map: Dict[str, str] = {}
+        for entity in self.entities.values():
+            entity_uri_map[entity.entity_id] = self._build_uri(entity.entity_id)
+        
+        for entity in self.entities.values():
+            node = {
+                "@id": entity_uri_map[entity.entity_id],
+                "@type": entity.schema_type,
+                "name": entity.name,
+                **entity.properties
+            }
+            graph.append(node)
+        
+        for relation in self.relations:
+            subject_uri = entity_uri_map.get(relation.subject_id)
+            object_uri = entity_uri_map.get(relation.object_id)
+            
+            if subject_uri and object_uri:
+                for node in graph:
+                    if node["@id"] == subject_uri:
+                        node[relation.predicate] = {"@id": object_uri}
+                        break
+        
+        return {
+            "@context": "https://schema.org",
+            "@graph": graph
+        }
+    
+    def to_rdf(self) -> str:
+        """Export as RDF/Turtle format."""
+        lines = [
+            "@prefix schema: <https://schema.org/> .",
+            f"@prefix kg: <{self.URI_PREFIX}:> .",
+            ""
+        ]
+        
+        for entity in self.entities.values():
+            clean_id = self._sanitize_id(entity.entity_id)
+            lines.append(f'kg:{clean_id} a schema:{entity.schema_type} ;')
+            lines.append(f'    schema:name "{entity.name}" .')
+            lines.append("")
+        
+        for relation in self.relations:
+            subject_id = self._sanitize_id(relation.subject_id)
+            object_id = self._sanitize_id(relation.object_id)
+            lines.append(f'kg:{subject_id} schema:{relation.predicate} kg:{object_id} .')
+        
+        return "\n".join(lines)
+    
+    def get_stats(self) -> Dict[str, int]:
+        """Get statistics about the knowledge graph."""
+        return {
+            "entities": len(self.entities),
+            "relations": len(self.relations),
+            "texts_processed": len(self.texts)
+        }

--- a/backend/app/vendor/tom_kg/schema_loader.py
+++ b/backend/app/vendor/tom_kg/schema_loader.py
@@ -1,0 +1,80 @@
+"""
+Schema.org Type Loader
+
+Loads and queries Schema.org type definitions for entity alignment.
+"""
+
+import rdflib
+from typing import Dict, List, Optional
+
+
+class SchemaOrgLoader:
+    """Load and query Schema.org type definitions."""
+    
+    def __init__(self, schema_path: str = None):
+        self.graph = rdflib.Graph()
+        self.types: Dict[str, dict] = {}
+        self.properties: Dict[str, dict] = {}
+        if schema_path:
+            self._load_schema(schema_path)
+    
+    def _load_schema(self, path: str):
+        """Load schema.org definitions from JSON-LD."""
+        self.graph.parse(path, format="json-ld")
+        
+        # Extract types (Classes)
+        for s, p, o in self.graph.triples((None, rdflib.RDF.type, rdflib.RDFS.Class)):
+            type_id = str(s).replace("http://schema.org/", "").replace("https://schema.org/", "")
+            self.types[type_id] = {
+                "uri": str(s),
+                "label": type_id,
+                "supertypes": self._get_supertypes(s),
+                "properties": []
+            }
+        
+        # Extract properties
+        for s, p, o in self.graph.triples((None, rdflib.RDF.type, rdflib.RDF.Property)):
+            prop_id = str(s).replace("http://schema.org/", "").replace("https://schema.org/", "")
+            self.properties[prop_id] = {
+                "uri": str(s),
+                "label": prop_id,
+                "domain_includes": self._get_domain(s),
+                "range_includes": self._get_range(s)
+            }
+    
+    def _get_supertypes(self, uri) -> List[str]:
+        """Get parent types."""
+        supers = []
+        for _, _, o in self.graph.triples((uri, rdflib.RDFS.subClassOf, None)):
+            supers.append(str(o).replace("http://schema.org/", "").replace("https://schema.org/", ""))
+        return supers
+    
+    def _get_domain(self, uri) -> List[str]:
+        """Get domain types for a property."""
+        domain_uri = rdflib.URIRef("http://schema.org/domainIncludes")
+        return [str(o).replace("http://schema.org/", "").replace("https://schema.org/", "") 
+                for _, _, o in self.graph.triples((uri, domain_uri, None))]
+    
+    def _get_range(self, uri) -> List[str]:
+        """Get range types for a property."""
+        range_uri = rdflib.URIRef("http://schema.org/rangeIncludes")
+        return [str(o).replace("http://schema.org/", "").replace("https://schema.org/", "") 
+                for _, _, o in self.graph.triples((uri, range_uri, None))]
+    
+    def get_common_types(self) -> List[str]:
+        """Get commonly used entity types for extraction."""
+        return [
+            "Person", "Organization", "Place", "Event", "Product",
+            "CreativeWork", "LocalBusiness", "Article", "Book", 
+            "Movie", "Restaurant", "Hotel", "MedicalEntity",
+            "City", "Country", "Corporation", "SoftwareApplication"
+        ]
+    
+    def get_common_properties(self) -> List[str]:
+        """Get commonly used properties for relationships."""
+        return [
+            "worksFor", "location", "knows", "memberOf", "author",
+            "creator", "attendee", "manufacturer", "founder",
+            "employee", "alumni", "parentOrganization", "subOrganization",
+            "jobTitle", "description", "name", "url"
+        ]

--- a/backend/app/vendor/tom_kg/schemaorg_entity_extractor.py
+++ b/backend/app/vendor/tom_kg/schemaorg_entity_extractor.py
@@ -1,0 +1,141 @@
+"""
+Schema.org Entity Extractor
+
+LLM-based entity extraction with Schema.org type mapping.
+"""
+
+from typing import List, Dict, Tuple
+import json
+
+
+class SchemaOrgEntityExtractor:
+    """Extract entities from text and map to Schema.org types."""
+    
+    # Mapping from entity categories to Schema.org types
+    TYPE_MAPPING = {
+        "person": "Person",
+        "people": "Person",
+        "company": "Organization",
+        "organization": "Organization",
+        "corporation": "Corporation",
+        "startup": "Organization",
+        "location": "Place",
+        "place": "Place",
+        "city": "City",
+        "country": "Country",
+        "address": "PostalAddress",
+        "event": "Event",
+        "conference": "Event",
+        "meeting": "Event",
+        "product": "Product",
+        "software": "SoftwareApplication",
+        "service": "Service",
+        "article": "Article",
+        "book": "Book",
+        "movie": "Movie",
+        "restaurant": "Restaurant",
+        "hotel": "Hotel",
+    }
+    
+    # Relationship mapping to Schema.org properties
+    RELATION_MAPPING = {
+        "works_for": "worksFor",
+        "works_at": "worksFor",
+        "employed_by": "worksFor",
+        "employee_of": "worksFor",
+        "located_in": "location",
+        "located_at": "location",
+        "based_in": "location",
+        "headquarters": "location",
+        "knows": "knows",
+        "met": "knows",
+        "colleague": "colleague",
+        "member_of": "memberOf",
+        "part_of": "memberOf",
+        "created": "creator",
+        "author_of": "author",
+        "founded": "founder",
+        "manufacturer": "manufacturer",
+        "produces": "manufacturer",
+        "made_by": "manufacturer",
+        "attended": "attendee",
+        "participated_in": "attendee",
+        "spoke_at": "performer",
+        "ceo_of": "employee",
+        "leads": "employee",
+        "subsidiary_of": "parentOrganization",
+        "owns": "ownerOf",
+    }
+    
+    def __init__(self, llm_client, schema_loader=None):
+        self.llm_client = llm_client
+        self.schema_loader = schema_loader
+        
+    def extract_entities_and_relations(self, text: str) -> Tuple[List[Dict], List[Dict]]:
+        """Use LLM to extract entities and relations aligned with Schema.org."""
+        
+        common_types = ["Person", "Organization", "Place", "Event", "Product", "CreativeWork"]
+        
+        prompt = f"""Analyze the following text and extract ALL entities and relationships.
+
+Text: "{text}"
+
+Instructions:
+1. Extract EVERY named entity (people, organizations, places, events, products, etc.)
+2. Extract ALL relationships between entities, including implicit ones
+3. Resolve coreferences (e.g., "She" -> "Alice", "Their" -> the company mentioned)
+4. For job titles like "CEO", "engineer", extract as a property AND as a relationship
+
+Entity Types to use: {', '.join(common_types)}
+
+Relationship predicates to use:
+- worksFor (person works at organization)
+- location (thing is located at place)
+- knows (person knows person)
+- attendee (person attended event)
+- manufacturer (organization makes product)
+- founder (person founded organization)
+- jobTitle (person's role - as property)
+
+Respond ONLY with valid JSON:
+{{
+    "entities": [
+        {{
+            "name": "exact name from text",
+            "type": "Person|Organization|Place|Event|Product",
+            "properties": {{"jobTitle": "...", "description": "..."}}
+        }}
+    ],
+    "relations": [
+        {{
+            "subject": "entity name",
+            "predicate": "worksFor|location|knows|attendee|manufacturer",
+            "object": "entity name"
+        }}
+    ]
+}}
+
+Be thorough - extract every entity and relationship mentioned or implied."""
+
+        response = self.llm_client.generate(prompt)
+        return self._parse_response(response)
+    
+    def _parse_response(self, response: str) -> Tuple[List[Dict], List[Dict]]:
+        """Parse LLM response into entities and relations."""
+        try:
+            # Handle markdown code blocks if present
+            if "```json" in response:
+                response = response.split("```json")[1].split("```")[0]
+            elif "```" in response:
+                response = response.split("```")[1].split("```")[0]
+            
+            data = json.loads(response.strip())
+            return data.get("entities", []), data.get("relations", [])
+        except json.JSONDecodeError as e:
+            print(f"Warning: Failed to parse LLM response: {e}")
+            return [], []
+    
+    def map_to_schemaorg(self, entity_type: str) -> str:
+        """Map extracted entity type to Schema.org URI."""
+        schema_type = self.TYPE_MAPPING.get(entity_type.lower(), "Thing")
+        return f"https://schema.org/{schema_type}"

--- a/backend/app/vendor/tom_kg/schemaorg_memory_entry.py
+++ b/backend/app/vendor/tom_kg/schemaorg_memory_entry.py
@@ -1,0 +1,59 @@
+"""
+Schema.org Memory Entry Models
+
+Pydantic models for entities, relations, and knowledge graph entries
+aligned with Schema.org types.
+"""
+
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field
+import uuid
+
+
+class SchemaOrgEntity(BaseModel):
+    """An entity aligned with Schema.org types."""
+    entity_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str
+    schema_type: str  # e.g., "Person", "Organization", "Place"
+    schema_uri: str   # e.g., "https://schema.org/Person"
+    properties: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SchemaOrgRelation(BaseModel):
+    """A relationship between entities using Schema.org properties."""
+    subject_id: str
+    predicate: str      # Schema.org property, e.g., "worksFor", "location"
+    predicate_uri: str  # e.g., "https://schema.org/worksFor"
+    object_id: str
+
+
+class KnowledgeGraphEntry(BaseModel):
+    """Extended memory entry with Schema.org alignment."""
+    entry_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    
+    # Original text fields
+    lossless_restatement: str
+    keywords: List[str] = Field(default_factory=list)
+    timestamp: Optional[str] = None
+    location: Optional[str] = None
+    
+    # Schema.org-aligned entities
+    entities: List[SchemaOrgEntity] = Field(default_factory=list)
+    relations: List[SchemaOrgRelation] = Field(default_factory=list)
+    
+    def to_jsonld(self) -> Dict[str, Any]:
+        """Convert to JSON-LD format."""
+        graph = []
+        for entity in self.entities:
+            node = {
+                "@id": f"urn:kg:{entity.entity_id}",
+                "@type": entity.schema_type,
+                "name": entity.name,
+                **entity.properties
+            }
+            graph.append(node)
+        
+        return {
+            "@context": "https://schema.org",
+            "@graph": graph
+        }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,14 @@ celery==5.4.0
 
 # LLM
 litellm==1.52.16
+# openai SDK is pulled transitively by litellm, but Tom's vendored KG
+# constructor (`app/vendor/tom_kg`) imports it directly — pin explicitly
+# so a litellm upgrade can't silently yank it out from under us.
+openai==2.24.0
+
+# Knowledge graph — Schema.org alignment via Tom's vendored library.
+# rdflib parses schema.org JSON-LD in SchemaOrgLoader; `>=6.0.0` per upstream.
+rdflib==7.1.1
 
 # Search / Vector / Graph
 elasticsearch==8.15.1


### PR DESCRIPTION
Closes #47. Based on `feat/48-kg-extraction-pipeline` (PR #91); will retarget to `main` once #91 merges.

## What this does

Replaces the hand-rolled LLM NER in `kg_extract.py` (from #48) with Tom's `KnowledgeGraphConstructor`. Entities are now aligned to the Schema.org ontology (Person, Organization, Place, SoftwareApplication, …) and relations to Schema.org properties (worksFor, location, founder, …), as Zoey's brief specified.

## Changes

### Vendor
- `backend/app/vendor/tom_kg/` — 5 files from [imadcat/simplemem_schemaorg-kg-constructor@320610e](https://github.com/imadcat/simplemem_schemaorg-kg-constructor) (MIT). Only modification: absolute → relative cross-imports so the flat module repo can live inside a Python package. No logic changes.
- Vendored (not `pip install from git`) because the upstream repo doesn't publish to PyPI, and hash-pinning git URLs in Docker/Fly builds is brittle.

### Dependencies (`backend/requirements.txt`)
- `openai==2.24.0` — explicit pin. Tom's `LLMClient` imports it directly; today it comes in transitively via litellm, but we shouldn't rely on that.
- `rdflib==7.1.1` — `SchemaOrgLoader` parses schema.org JSON-LD.

### `app/services/kg_extract.py` — rewrite
- **Removed**: `_SYSTEM_PROMPT`, `_call_llm`, `_parse_json_block`, `_build_user_prompt`, `_FENCE_RE` — all subsumed by Tom's library.
- **Removed**: dependency on `graph_vocab.EntityType` / `RelationType` for Postgres writes — those columns are plain `String`, so Schema.org type names fit natively.
- **Preserved**: per-chunk LLM call (`MAX_CHUNKS_PER_DOC=20`, `CHUNK_CHAR_CAP=2000`) — same cost profile as #48. Chunk provenance via diffing Tom's internal `kg.entities.keys()` before/after each `add_text()`.
- **Preserved**: MENTIONED_IN edges with `{chunk_index: N}`.
- **Preserved**: `extract_and_persist(db, document_id)` signature — `kg_pipeline.py` keeps calling it unchanged.
- **external_id stays slug-based** (`ent:<schema_type>:<slug>`) rather than using Tom's per-run UUID. UUIDs would break cross-document dedup. Tom's UUID is kept in `properties.tom_entity_id` for within-run relation resolution; `schema_uri` stored for future ontology-aware queries.
- **Neo4j mirror extended**: now pushes inter-entity Schema.org relations too, not just MENTIONED_IN — scoped to entities touched by this document's slice.
- **Sync all the way down**: Celery worker is sync, Tom's `LLMClient` is sync — no more `asyncio.run(llm.complete(...))` in the hot path.

### `app/services/graph_sync.py` — whitelist → regex
Changed entity/relation type validation from enum-membership (6 types, 5 relations) to identifier-shape regex `^[A-Za-z_]\w{0,63}$`. Schema.org has ~700 classes; enumerating them defeats the point of using the ontology.
- Keeps Cypher-injection safety (Cypher labels can't be parameterised).
- 14/14 positive+negative test cases green, including quote/backtick/semicolon/keyword injection.

## Preserved invariants

- `NonRetryableError` still lives in `kg_pipeline.py` (orchestrator concern). `kg_extract` raises `ValueError` for deterministic failures (missing KnowledgeItem), which the stage runner maps to FAILED.
- Celery `autoretry_for` from #91 excludes both `NonRetryableError` and `ValueError` — deterministic failures won't burn retries.
- `kg_status` / `kg_stage` / `kg_error` state machine untouched.
- Idempotency: `KGNode.external_id` unique + `(source_id, target_id, relation_type)` unique constraint means re-running is safe.

## Decisions left for follow-up

- **PR #94 Cypher builder alignment**: PR #94's Agent API whitelists `ENTITY_TYPES` / `RELATION_TYPES` (the 6+5 enum). Schema.org types now flowing into Neo4j won't be queryable via `/api/agent/kg/query` until #94's whitelist is aligned with `graph_sync._SAFE_LABEL_RE`. File a follow-up once #94 merges. Not blocking this PR — Agent API reads degrade to empty bucket for unknown labels.
- **Chinese-language prompt**: Tom's extractor prompt is English. EKM content is predominantly Chinese; worth benchmarking recall on a real corpus and deciding if we need a prompt override. Not blocking — v1 behaviour of shipping the upstream prompt lets us measure before deciding.

## Test plan

- [ ] Unit: isolated tests pass (regex 14/14, external_id 8/8) — covered in commit.
- [ ] Integration: upload a doc, run pipeline, verify `kg_nodes.entity_type` has Schema.org values + `kg_edges.relation_type` has predicates like `worksFor`.
- [ ] Neo4j: query `MATCH (n:Person) RETURN n.label` returns nodes (was previously forced to `:Entity`).
- [ ] Sage review.

Cc @Sage for review once Tom PR #91 merges and this gets retargeted to main.