### PR TITLE
fix: #96 文件上传 500 — 修正 Enum 大小写错配

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -61,8 +61,11 @@ class DocumentParseRecord(Base):
         nullable=False,
         index=True,
     )
+    # See knowledge.py file_type — same values_callable fix. `parsestatus`
+    # Postgres enum was created with lowercase values in 0002.
     status: Mapped[ParseStatus] = mapped_column(
-        Enum(ParseStatus), default=ParseStatus.PENDING, nullable=False,
+        Enum(ParseStatus, values_callable=lambda obj: [e.value for e in obj]),
+        default=ParseStatus.PENDING, nullable=False,
     )
     task_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -43,7 +43,13 @@ class ChatFeedback(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True,
     )
     rating: Mapped[FeedbackRating] = mapped_column(
-        Enum(FeedbackRating, name="feedback_rating"), nullable=False, index=True,
+        # values_callable aligns with lowercase enum values created in 0005.
+        Enum(
+            FeedbackRating,
+            values_callable=lambda obj: [e.value for e in obj],
+            name="feedback_rating",
+        ),
+        nullable=False, index=True,
     )
     # Free-form — optional note "wrong source" / "hallucinated X" etc.
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -80,7 +80,16 @@ class KnowledgeItem(Base):
     name: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     file_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
-    file_type: Mapped[FileType] = mapped_column(Enum(FileType), default=FileType.OTHER, nullable=False)
+    # values_callable is load-bearing: the `filetype` Postgres enum type was
+    # created with lowercase values ("document", "image", …) in 0001, but
+    # SQLAlchemy's default is to serialize Python enum *names* (uppercase
+    # "DOCUMENT"). Mismatch → every insert raises
+    # `invalid input value for enum filetype: "DOCUMENT"`. Pin to `.value`
+    # so what we write matches what Postgres declared.
+    file_type: Mapped[FileType] = mapped_column(
+        Enum(FileType, values_callable=lambda obj: [e.value for e in obj]),
+        default=FileType.OTHER, nullable=False,
+    )
     mime_type: Mapped[str | None] = mapped_column(String(200), nullable=True)
     size: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
     download_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)


### PR DESCRIPTION
Closes #96.

## Symptom

All file uploads return 500:
```
invalid input value for enum filetype: "DOCUMENT"
```

## Root cause

SQLAlchemy's default `Enum(PyEnum)` binds the Python enum *name*
(uppercase `DOCUMENT`) into the DB. But the `filetype` Postgres enum
type was created in migration 0001 with lowercase values
(`"document"`, `"image"`, `"archive"`, `"audio"`, `"video"`,
`"other"`) — matching our Python `FileType.X.value`, not `.name`.

Name ≠ value → every insert fails at the type-check barrier.

## Fix

Add `values_callable=lambda obj: [e.value for e in obj]` to the three
offending columns. Same pattern already used on `user.role`,
`kg_status`, sharing, restore, notification, archive — it's just
these three that were missed.

| File | Column | DB enum type | Migration |
|---|---|---|---|
| `app/models/knowledge.py` | `file_type` | `filetype` | 0001 |
| `app/models/document.py` | `status` (ParseStatus) | `parsestatus` | 0002 |
| `app/models/feedback.py` | `rating` (FeedbackRating) | `feedback_rating` | 0005 |

The first is the one Mira's E2E hit (every upload 500s). The other
two would surface on the next parse attempt / next thumbs-up/down,
so I swept them in the same pass per Zoey's 「顺手检查」 ask.

## No migration

Postgres enum types already hold the correct lowercase values. The
bug was in the ORM→DB binding direction, not in the DB schema. No
Alembic change.

## Verified

- Isolated smoke test: with `values_callable`, SQLAlchemy's
  `Enum.enums` reports `['document', 'image', 'archive', …]`;
  without it, `['DOCUMENT', 'IMAGE', 'ARCHIVE', …]`.
- Full-app integration test blocked on adding a pytest harness —
  I'll add a regression test for this alongside the pytest work
  in PR #94's followup.

## Test plan

- [ ] Staging: upload one of each file type (document / image /
      archive / audio / video / other) — should succeed with 2xx.
- [ ] Staging: parse a document — no `invalid input value for
      enum parsestatus` error in logs.
- [ ] Staging: give a thumbs-up on chat — chat_feedback row inserts
      cleanly.

—— Kira