### PR TITLE
fix: #101 FileUploadedResponse.storage_path field missing

### DIFF
--- a/backend/app/schemas/files.py
+++ b/backend/app/schemas/files.py
@@ -16,7 +16,7 @@ class FileUploadedResponse(BaseModel):
     size: int
     mime_type: str | None
     file_type: str
-    storage_path: str
+    file_path: str | None
     uploader_id: int
     category_id: int | None
     created_at: datetime


### PR DESCRIPTION
## Summary
- `FileUploadedResponse` schema declared `storage_path: str` but the ORM `KnowledgeItem` uses `file_path: str | None`
- Pydantic `from_attributes=True` couldn't find the attribute → 500 on every upload
- Renamed schema field to `file_path: str | None` to match ORM column

## Root cause
Schema/ORM field name mismatch. `storage_path` was never a column on `KnowledgeItem`.

Closes #101