### PR TITLE
fix: #103 openapi.json ForwardRef + agent token seed script

### DIFF
--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -3,9 +3,12 @@
 Schemas here are the contract Tom's Agent (and others) build against.
 Keep them conservative — a loose schema today is a backward-compat
 nightmare tomorrow.
-"""
-from __future__ import annotations
 
+NOTE: Do NOT add ``from __future__ import annotations`` to this file.
+Pydantic v2's ForwardRef resolution breaks with postponed evaluation in
+certain import-order scenarios, causing ``/openapi.json`` to 500.
+Python 3.10+ supports all the syntax we need natively.
+"""
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/backend/scripts/seed_agent_token.py
+++ b/backend/scripts/seed_agent_token.py
@@ -11,6 +11,9 @@ Usage:
 
 Prints the plaintext token exactly once. Copy it — there's no way to
 recover it after this script exits.
+
+Idempotent: if a token with the same name already exists, prints its
+prefix and exits without creating a duplicate.
 """
 import asyncio
 import sys
@@ -19,8 +22,10 @@ from pathlib import Path
 # Ensure the backend package is importable when running as a script.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from sqlalchemy import select
+
 from app.core.agent_security import generate_agent_token
-from app.core.database import AsyncSessionFactory
+from app.core.database import AsyncSessionLocal
 from app.models.agent import AgentToken
 
 
@@ -31,9 +36,17 @@ SEED_CREATED_BY = 1
 
 
 async def main() -> None:
-    tok = generate_agent_token()
+    async with AsyncSessionLocal() as db:
+        # Idempotent: skip if already seeded.
+        existing = (await db.execute(
+            select(AgentToken).where(AgentToken.name == SEED_NAME)
+        )).scalar_one_or_none()
+        if existing is not None:
+            print(f"Token '{SEED_NAME}' already exists (prefix={existing.token_prefix}).")
+            print("Delete it manually if you need to re-seed.")
+            return
 
-    async with AsyncSessionFactory() as db:
+        tok = generate_agent_token()
         row = AgentToken(
             name=SEED_NAME,
             token_prefix=tok.prefix,

--- a/backend/scripts/seed_agent_token.py
+++ b/backend/scripts/seed_agent_token.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Seed a test AgentToken for staging / local dev.
+
+Usage:
+    # From backend/ directory (with .env loaded):
+    python -m scripts.seed_agent_token
+
+    # Or via flyctl on staging:
+    flyctl ssh console -a ekm-backend -C \
+      "cd /app && python -m scripts.seed_agent_token"
+
+Prints the plaintext token exactly once. Copy it — there's no way to
+recover it after this script exits.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+# Ensure the backend package is importable when running as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.agent_security import generate_agent_token
+from app.core.database import AsyncSessionFactory
+from app.models.agent import AgentToken
+
+
+SEED_NAME = "mira-staging-test"
+SEED_SCOPES = ["knowledge:read", "kg:read", "kg:write"]
+# created_by_id=1 assumes the first user (admin) exists. Adjust if needed.
+SEED_CREATED_BY = 1
+
+
+async def main() -> None:
+    tok = generate_agent_token()
+
+    async with AsyncSessionFactory() as db:
+        row = AgentToken(
+            name=SEED_NAME,
+            token_prefix=tok.prefix,
+            token_hash=tok.hashed,
+            scopes=SEED_SCOPES,
+            created_by_id=SEED_CREATED_BY,
+            is_active=True,
+        )
+        db.add(row)
+        await db.commit()
+
+    print("--- Agent token seeded ---")
+    print(f"  Name:      {SEED_NAME}")
+    print(f"  Prefix:    {tok.prefix}")
+    print(f"  Scopes:    {SEED_SCOPES}")
+    print(f"  Plaintext: {tok.plaintext}")
+    print()
+    print("Copy the plaintext above. It cannot be recovered.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- **#103 fix**: removed `from __future__ import annotations` from `schemas/agent.py` — it caused Pydantic v2 ForwardRef resolution to break, crashing `/openapi.json` and `/docs`
- **Agent token seed**: added `scripts/seed_agent_token.py` for Mira's C-4 rate-limit verification on staging

## Root cause (#103)
`from __future__ import annotations` makes all type annotations strings (PEP 563). Pydantic v2 needs to resolve these at schema-build time for FastAPI's OpenAPI generation. With the deferred annotations, `KGQueryRequest` stayed as an unresolved `ForwardRef`, causing a `TypeAdapter` crash on `/openapi.json`.

Closes #103