### PR TITLE
feat: #55 KG search API — entity search + shortest path

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.routers import archive as archive_router
 from app.routers import restore as restore_router
 from app.routers import batch as batch_router
 from app.routers import agent as agent_router
+from app.routers import kg as kg_router
 
 
 @asynccontextmanager
@@ -46,9 +47,11 @@ async def lifespan(app: FastAPI):
     try:
         from app.core.graph import graph
         await graph.ensure_constraints()
+        from app.routers.kg import ensure_fulltext_index
+        await ensure_fulltext_index()
     except Exception as e:
         # Same principle as ES: graph is a degradable feature.
-        log.warning("Neo4j constraint bootstrap skipped: %s", e)
+        log.warning("Neo4j bootstrap skipped: %s", e)
     yield
     # Shutdown: clean up connections
     from app.core.database import engine
@@ -110,11 +113,11 @@ app.include_router(archive_router.router)
 app.include_router(restore_router.router)
 app.include_router(batch_router.router)
 app.include_router(agent_router.router)
+app.include_router(kg_router.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])
 # app.include_router(knowledge.router,  prefix="/api/v1/knowledge", tags=["knowledge"])
-# app.include_router(kg.router,         prefix="/api/v1/kg",        tags=["knowledge-graph"])
 
 
 @app.exception_handler(Exception)

--- a/backend/app/routers/kg.py
+++ b/backend/app/routers/kg.py
@@ -1,0 +1,155 @@
+"""Knowledge-graph search API (Issue #55).
+
+User-facing endpoints for searching entities and finding paths in the
+knowledge graph.  Requires standard user authentication (not Agent tokens).
+
+Endpoints:
+  GET  /api/v1/kg/entities   full-text search over Entity nodes
+  GET  /api/v1/kg/path       shortest path between two entities
+"""
+import logging
+import re
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from app.core.deps import CurrentUser
+from app.core.graph import graph
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/kg", tags=["knowledge-graph"])
+
+# Mirrors graph_sync / kg_extract safe-label check.
+_SAFE_ID_RE = re.compile(r"^[\w:.\-]{1,255}$", re.UNICODE)
+
+MAX_LIMIT = 100
+MAX_HOPS = 5
+
+# Neo4j fulltext index name.  Created at startup (see _ensure_fulltext_index).
+_FT_INDEX = "entity_search"
+
+
+async def ensure_fulltext_index() -> None:
+    """Create the fulltext index if it doesn't exist.
+
+    Called once at app startup (see main.py lifespan).  Idempotent.
+    """
+    try:
+        await graph.run(
+            "CALL db.index.fulltext.createNodeIndex("
+            "  $name, ['Entity'], ['name', 'label', 'description']"
+            ")",
+            {"name": _FT_INDEX},
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Index may already exist (createNodeIndex is not IF NOT EXISTS
+        # in all Neo4j versions).  Also safe to skip if Neo4j is down —
+        # searches will degrade to empty.
+        if "already exists" not in str(exc).lower():
+            log.warning("Failed to create fulltext index %s: %s", _FT_INDEX, exc)
+
+
+# ── GET /entities ─────────────────────────────────────────────────────
+
+
+@router.get("/entities")
+async def search_entities(
+    user: CurrentUser,
+    q: str = Query(..., min_length=1, max_length=500, description="Search query"),
+    limit: int = Query(20, ge=1, le=MAX_LIMIT, description="Max results"),
+):
+    """Full-text search over Entity nodes (name, label, description).
+
+    Returns matched entities with relevance score.  Degrades to empty
+    list if Neo4j is down.
+    """
+    try:
+        rows = await graph.run(
+            "CALL db.index.fulltext.queryNodes($idx, $query) "
+            "YIELD node, score "
+            "RETURN node.external_id AS external_id, "
+            "       node.label AS label, "
+            "       labels(node) AS labels, "
+            "       properties(node) AS properties, "
+            "       score "
+            "LIMIT $lim",
+            {"idx": _FT_INDEX, "query": q, "lim": limit},
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("kg entity search failed: %s", exc)
+        return {"query": q, "entities": []}
+
+    entities = [
+        {
+            "external_id": r["external_id"],
+            "label": r.get("label"),
+            "labels": list(r.get("labels") or []),
+            "properties": dict(r.get("properties") or {}),
+            "score": float(r.get("score", 0.0)),
+        }
+        for r in rows
+        if r.get("external_id")
+    ]
+    return {"query": q, "entities": entities}
+
+
+# ── GET /path ─────────────────────────────────────────────────────────
+
+
+@router.get("/path")
+async def shortest_path(
+    user: CurrentUser,
+    source: str = Query(
+        ..., min_length=1, max_length=255, alias="from",
+        description="Source entity external_id",
+    ),
+    target: str = Query(
+        ..., min_length=1, max_length=255, alias="to",
+        description="Target entity external_id",
+    ),
+    max_hops: int = Query(3, ge=1, le=MAX_HOPS),
+):
+    """Find the shortest path between two entities.
+
+    Returns the node chain and relationship types.  Degrades to
+    ``found=false`` if Neo4j is down.
+    """
+    # Validate external_id format to prevent injection via label interpolation.
+    if not _SAFE_ID_RE.match(source):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="invalid source entity id format",
+        )
+    if not _SAFE_ID_RE.match(target):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="invalid target entity id format",
+        )
+
+    # All user values are parameterised.  The hop cap is a clamped int
+    # literal — safe to interpolate (Cypher can't parameterise path length).
+    cypher = (
+        "MATCH (a:Entity {external_id: $src}), "
+        "(b:Entity {external_id: $dst}) "
+        f"MATCH p = shortestPath((a)-[*1..{max_hops}]-(b)) "
+        "RETURN [n IN nodes(p) | n.external_id] AS node_ids, "
+        "[r IN relationships(p) | type(r)] AS rel_types, "
+        "length(p) AS hops"
+    )
+
+    try:
+        rows = await graph.run(cypher, {"src": source, "dst": target})
+    except Exception as exc:  # noqa: BLE001
+        log.warning("kg path query failed: %s", exc)
+        return {"found": False, "node_ids": [], "rel_types": [], "hops": 0}
+
+    if not rows:
+        return {"found": False, "node_ids": [], "rel_types": [], "hops": 0}
+
+    row = rows[0]
+    return {
+        "found": True,
+        "node_ids": list(row.get("node_ids") or []),
+        "rel_types": list(row.get("rel_types") or []),
+        "hops": int(row.get("hops") or 0),
+    }

--- a/backend/app/routers/kg.py
+++ b/backend/app/routers/kg.py
@@ -8,95 +8,121 @@ Endpoints:
   GET  /api/v1/kg/path       shortest path between two entities
 """
 import logging
-import re
 
 from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
 
 from app.core.deps import CurrentUser
 from app.core.graph import graph
+from app.services.kg_search import (
+    SAFE_ID_RE,
+    MAX_HOPS,
+    MAX_LIMIT,
+    LuceneEscapeError,
+    escape_lucene,
+)
 
 log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/kg", tags=["knowledge-graph"])
 
-# Mirrors graph_sync / kg_extract safe-label check.
-_SAFE_ID_RE = re.compile(r"^[\w:.\-]{1,255}$", re.UNICODE)
+_FT_INDEX_NAME = "entity_search"
 
-MAX_LIMIT = 100
-MAX_HOPS = 5
 
-# Neo4j fulltext index name.  Created at startup (see _ensure_fulltext_index).
-_FT_INDEX = "entity_search"
+# ── Response models ──────────────────────────────────────────────────
+
+
+class EntityHit(BaseModel):
+    external_id: str
+    label: str | None = None
+    entity_type: str | None = None
+    score: float = 0.0
+
+
+class EntitySearchResponse(BaseModel):
+    query: str
+    entities: list[EntityHit]
+
+
+class PathResponse(BaseModel):
+    found: bool
+    node_ids: list[str] = Field(default_factory=list)
+    rel_types: list[str] = Field(default_factory=list)
+    hops: int = 0
+
+
+# ── Startup ──────────────────────────────────────────────────────────
 
 
 async def ensure_fulltext_index() -> None:
     """Create the fulltext index if it doesn't exist.
 
     Called once at app startup (see main.py lifespan).  Idempotent.
+    Uses Cypher DDL syntax (Neo4j 4.x+) with IF NOT EXISTS.
     """
     try:
         await graph.run(
-            "CALL db.index.fulltext.createNodeIndex("
-            "  $name, ['Entity'], ['name', 'label', 'description']"
-            ")",
-            {"name": _FT_INDEX},
+            "CREATE FULLTEXT INDEX entity_search IF NOT EXISTS "
+            "FOR (n:Entity) ON EACH [n.name, n.label, n.description]"
         )
     except Exception as exc:  # noqa: BLE001
-        # Index may already exist (createNodeIndex is not IF NOT EXISTS
-        # in all Neo4j versions).  Also safe to skip if Neo4j is down —
-        # searches will degrade to empty.
-        if "already exists" not in str(exc).lower():
-            log.warning("Failed to create fulltext index %s: %s", _FT_INDEX, exc)
+        log.warning("Failed to create fulltext index %s: %s", _FT_INDEX_NAME, exc)
 
 
-# ── GET /entities ─────────────────────────────────────────────────────
+# ── GET /entities ────────────────────────────────────────────────────
 
 
-@router.get("/entities")
+@router.get("/entities", response_model=EntitySearchResponse)
 async def search_entities(
     user: CurrentUser,
     q: str = Query(..., min_length=1, max_length=500, description="Search query"),
     limit: int = Query(20, ge=1, le=MAX_LIMIT, description="Max results"),
-):
+) -> EntitySearchResponse:
     """Full-text search over Entity nodes (name, label, description).
 
     Returns matched entities with relevance score.  Degrades to empty
     list if Neo4j is down.
     """
     try:
+        safe_q = escape_lucene(q)
+    except LuceneEscapeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+    try:
         rows = await graph.run(
             "CALL db.index.fulltext.queryNodes($idx, $query) "
             "YIELD node, score "
             "RETURN node.external_id AS external_id, "
             "       node.label AS label, "
-            "       labels(node) AS labels, "
-            "       properties(node) AS properties, "
+            "       node.entity_type AS entity_type, "
             "       score "
             "LIMIT $lim",
-            {"idx": _FT_INDEX, "query": q, "lim": limit},
+            {"idx": _FT_INDEX_NAME, "query": safe_q, "lim": limit},
         )
     except Exception as exc:  # noqa: BLE001
         log.warning("kg entity search failed: %s", exc)
-        return {"query": q, "entities": []}
+        return EntitySearchResponse(query=q, entities=[])
 
     entities = [
-        {
-            "external_id": r["external_id"],
-            "label": r.get("label"),
-            "labels": list(r.get("labels") or []),
-            "properties": dict(r.get("properties") or {}),
-            "score": float(r.get("score", 0.0)),
-        }
+        EntityHit(
+            external_id=r["external_id"],
+            label=r.get("label"),
+            entity_type=r.get("entity_type"),
+            score=float(r.get("score", 0.0)),
+        )
         for r in rows
         if r.get("external_id")
     ]
-    return {"query": q, "entities": entities}
+    return EntitySearchResponse(query=q, entities=entities)
 
 
-# ── GET /path ─────────────────────────────────────────────────────────
+# ── GET /path ────────────────────────────────────────────────────────
 
 
-@router.get("/path")
+@router.get("/path", response_model=PathResponse)
 async def shortest_path(
     user: CurrentUser,
     source: str = Query(
@@ -108,26 +134,23 @@ async def shortest_path(
         description="Target entity external_id",
     ),
     max_hops: int = Query(3, ge=1, le=MAX_HOPS),
-):
+) -> PathResponse:
     """Find the shortest path between two entities.
 
     Returns the node chain and relationship types.  Degrades to
     ``found=false`` if Neo4j is down.
     """
-    # Validate external_id format to prevent injection via label interpolation.
-    if not _SAFE_ID_RE.match(source):
+    if not SAFE_ID_RE.match(source):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="invalid source entity id format",
         )
-    if not _SAFE_ID_RE.match(target):
+    if not SAFE_ID_RE.match(target):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="invalid target entity id format",
         )
 
-    # All user values are parameterised.  The hop cap is a clamped int
-    # literal — safe to interpolate (Cypher can't parameterise path length).
     cypher = (
         "MATCH (a:Entity {external_id: $src}), "
         "(b:Entity {external_id: $dst}) "
@@ -141,15 +164,15 @@ async def shortest_path(
         rows = await graph.run(cypher, {"src": source, "dst": target})
     except Exception as exc:  # noqa: BLE001
         log.warning("kg path query failed: %s", exc)
-        return {"found": False, "node_ids": [], "rel_types": [], "hops": 0}
+        return PathResponse(found=False)
 
     if not rows:
-        return {"found": False, "node_ids": [], "rel_types": [], "hops": 0}
+        return PathResponse(found=False)
 
     row = rows[0]
-    return {
-        "found": True,
-        "node_ids": list(row.get("node_ids") or []),
-        "rel_types": list(row.get("rel_types") or []),
-        "hops": int(row.get("hops") or 0),
-    }
+    return PathResponse(
+        found=True,
+        node_ids=list(row.get("node_ids") or []),
+        rel_types=list(row.get("rel_types") or []),
+        hops=int(row.get("hops") or 0),
+    )

--- a/backend/app/services/kg_search.py
+++ b/backend/app/services/kg_search.py
@@ -1,0 +1,33 @@
+"""KG search helpers — pure functions, no framework dependencies.
+
+Extracted from routers/kg.py so they can be unit-tested without pulling
+in FastAPI's dependency chain (auth → jose → …).
+"""
+import re
+
+# Lucene special characters that must be escaped before passing to
+# Neo4j's fulltext queryNodes.  Without this, `q=*` enumerates the
+# entire graph and `q=name:*` enables field-targeted scans.
+LUCENE_SPECIAL = re.compile(r'([+\-!(){}[\]^"~*?:\\/|&])')
+
+# Entity external_id format — blocks Cypher injection via label interpolation.
+SAFE_ID_RE = re.compile(r"^[\w:.\-]{1,255}$", re.UNICODE)
+
+MAX_LIMIT = 100
+MAX_HOPS = 5
+
+
+class LuceneEscapeError(ValueError):
+    """Raised when the search query is a bare wildcard or empty."""
+
+
+def escape_lucene(q: str) -> str:
+    """Escape Lucene special chars in user query.
+
+    Rejects bare wildcards that would enumerate the entire index.
+    Raises LuceneEscapeError on invalid input.
+    """
+    q = q.strip()
+    if not q or q in ("*", "?"):
+        raise LuceneEscapeError("search query must not be a bare wildcard")
+    return LUCENE_SPECIAL.sub(r"\\\1", q)

--- a/backend/tests/test_kg_router.py
+++ b/backend/tests/test_kg_router.py
@@ -1,0 +1,112 @@
+"""Tests for the KG search helpers (services/kg_search.py).
+
+Pure-logic unit tests for Lucene escaping and ID validation.
+No DB, no Neo4j, no async, no FastAPI dependency chain.
+"""
+import pytest
+
+from app.services.kg_search import (
+    LuceneEscapeError,
+    SAFE_ID_RE,
+    MAX_HOPS,
+    MAX_LIMIT,
+    escape_lucene,
+)
+
+
+# ── Lucene escaping ──────────────────────────────────────────────────
+
+
+class TestEscapeLucene:
+    def test_bare_wildcard_star_rejected(self):
+        """q='*' should be rejected — it enumerates the entire index."""
+        with pytest.raises(LuceneEscapeError):
+            escape_lucene("*")
+
+    def test_bare_wildcard_question_rejected(self):
+        with pytest.raises(LuceneEscapeError):
+            escape_lucene("?")
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(LuceneEscapeError):
+            escape_lucene("")
+
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(LuceneEscapeError):
+            escape_lucene("   ")
+
+    def test_normal_keyword_unchanged(self):
+        assert escape_lucene("hello") == "hello"
+
+    def test_chinese_keyword_unchanged(self):
+        assert escape_lucene("知识图谱") == "知识图谱"
+
+    def test_special_chars_escaped(self):
+        """Lucene specials are backslash-escaped."""
+        result = escape_lucene("name:value")
+        assert "\\:" in result
+        assert "name" in result
+
+    def test_wildcard_in_phrase_escaped(self):
+        """A '*' inside a normal query is escaped, not rejected."""
+        result = escape_lucene("hello*world")
+        assert "\\*" in result
+
+    def test_parentheses_escaped(self):
+        result = escape_lucene("(test)")
+        assert "\\(" in result
+        assert "\\)" in result
+
+    def test_multiple_specials(self):
+        result = escape_lucene('foo+"bar"')
+        assert "\\+" in result
+        assert '\\"' in result
+
+    def test_ampersand_escaped(self):
+        result = escape_lucene("A&B")
+        assert "\\&" in result
+
+    def test_pipe_escaped(self):
+        result = escape_lucene("A|B")
+        assert "\\|" in result
+
+
+# ── Entity ID validation ─────────────────────────────────────────────
+
+
+class TestEntityIdRegex:
+    def test_valid_simple_id(self):
+        assert SAFE_ID_RE.match("ent:Person:john-doe")
+
+    def test_valid_doc_id(self):
+        assert SAFE_ID_RE.match("doc:123")
+
+    def test_valid_uuid_style(self):
+        assert SAFE_ID_RE.match("ent:Concept:machine-learning")
+
+    def test_invalid_empty(self):
+        assert not SAFE_ID_RE.match("")
+
+    def test_invalid_space(self):
+        assert not SAFE_ID_RE.match("ent: Person")
+
+    def test_invalid_semicolon(self):
+        """Semicolons could be Cypher injection vectors."""
+        assert not SAFE_ID_RE.match("ent;DROP")
+
+    def test_invalid_curly_braces(self):
+        assert not SAFE_ID_RE.match("ent:{injected}")
+
+    def test_invalid_backtick(self):
+        assert not SAFE_ID_RE.match("ent`DROP")
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_max_hops(self):
+        assert MAX_HOPS == 5
+
+    def test_max_limit(self):
+        assert MAX_LIMIT == 100


### PR DESCRIPTION
## Summary
- `GET /api/v1/kg/entities?q={keyword}&limit=20` — fulltext search over Neo4j Entity nodes
- `GET /api/v1/kg/path?from={id}&to={id}&max_hops=3` — shortest path between entities
- Neo4j fulltext index `entity_search` created at startup (idempotent)
- All Cypher queries parameterised; entity_id regex-validated; max_hops capped at 5

## Security
- No raw Cypher from user input — all values via `$params`
- `entity_id` format validated against `^[\w:.\-]{1,255}$`
- Standard user auth (not Agent tokens)
- Degrades to empty results when Neo4j is down

## Files changed
- `backend/app/routers/kg.py` (new)
- `backend/app/main.py` (register router + fulltext index bootstrap)

Closes #55