### PR TITLE
fix: add ekm-qdrant fly.toml with IPv6 binding

### DIFF
--- a/qdrant/fly.toml
+++ b/qdrant/fly.toml
@@ -1,0 +1,44 @@
+app = "ekm-qdrant"
+primary_region = "sin"
+
+[build]
+  image = "qdrant/qdrant:v1.11.0"
+
+[env]
+  # Bind to :: (all IPv6 interfaces) so Fly.io .internal DNS (IPv6) can reach
+  # this service from other apps in the same private network.
+  # Without this, Qdrant defaults to 0.0.0.0 (IPv4 only), and peer connections
+  # via ekm-qdrant.internal fail with ECONNREFUSED even though the machine is running.
+  QDRANT__SERVICE__HOST = "::"
+  QDRANT__SERVICE__HTTP_PORT = "6333"
+
+[[mounts]]
+  source = "ekm_qdrant_data"
+  destination = "/qdrant/storage"
+
+[[services]]
+  internal_port = 6333
+  protocol = "tcp"
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[services.ports]]
+    force_https = false
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.http_checks]]
+    grace_period = "15s"
+    interval = "30s"
+    method = "GET"
+    path = "/healthz"
+    timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"


### PR DESCRIPTION
## Problem

`ekm-qdrant` app was deployed without a version-controlled `fly.toml`. Two issues were discovered during ES+Qdrant backfill testing:

1. **Qdrant only binds IPv4** (`0.0.0.0:6333`), but Fly.io private network uses IPv6 for `.internal` DNS. Any app trying to reach `ekm-qdrant.internal:6333` gets `ECONNREFUSED`, even though the machine is running and health checks pass (health checks go through the Fly proxy which uses IPv4 loopback).

2. **`autostop=true`** — Fly's auto-start only triggers for connections going through the Fly proxy. Connections via `.internal` bypass the proxy, so a stopped Qdrant machine can never be auto-started by peer connections.

## Fix

- `QDRANT__SERVICE__HOST=::` — binds all IPv6 interfaces (Linux dual-stack, also covers IPv4)
- `auto_stop_machines = false` — keeps Qdrant always running so `.internal` connections are never blocked

Both changes have been applied directly to the running machine already. This PR persists them in version control.

## Test

After merge, `ekm-qdrant` deployments will reliably accept connections from `ekm-backend` via `http://ekm-qdrant.internal:6333`.

🤖 Raven / WarrenStartup DevOps