### PR TITLE
feat: admin reparse endpoint for historical files

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from app.routers import agent as agent_router
 from app.routers import kg as kg_router
 from app.routers import chunk_history as chunk_history_router
 from app.routers import kg_review as kg_review_router
+from app.routers import admin_reparse as admin_reparse_router
 
 
 @asynccontextmanager
@@ -118,6 +119,7 @@ app.include_router(agent_router.router)
 app.include_router(kg_router.router)
 app.include_router(chunk_history_router.router)
 app.include_router(kg_review_router.router)
+app.include_router(admin_reparse_router.router)
 
 # Placeholder stubs — will be filled in as each feature issue is implemented
 # app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])

--- a/backend/app/routers/admin_reparse.py
+++ b/backend/app/routers/admin_reparse.py
@@ -1,0 +1,69 @@
+"""Admin reparse endpoint.
+
+POST /api/v1/admin/reparse — re-queue historical items through the parse
+pipeline so they get DocumentChunks (and downstream ES/Qdrant indexing).
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.core.deps import CurrentUser, DB
+from app.models.document import DocumentParseRecord, ParseStatus
+from app.models.knowledge import KnowledgeItem
+from app.models.user import UserRole
+from app.worker.tasks import parse_document
+
+router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
+
+MAX_QUEUE = 200
+
+
+class ReparseRequest(BaseModel):
+    item_ids: list[int] | None = Field(default=None, description="Specific item IDs; omit for all unparsed")
+    force: bool = Field(default=False, description="True = ignore parse status, re-run everything")
+
+
+class ReparseResponse(BaseModel):
+    queued: int
+    skipped: int
+
+
+@router.post("/reparse", response_model=ReparseResponse, status_code=202)
+async def admin_reparse(body: ReparseRequest, db: DB, user: CurrentUser):
+    """Re-queue historical files through the Tika parse pipeline."""
+    if user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+
+    # Resolve candidate items.
+    if body.item_ids:
+        stmt = select(KnowledgeItem.id).where(KnowledgeItem.id.in_(body.item_ids))
+    else:
+        stmt = select(KnowledgeItem.id)
+    all_ids: list[int] = list((await db.execute(stmt)).scalars().all())
+
+    if not body.force:
+        # Exclude items that already have status=PARSED.
+        parsed_ids_stmt = (
+            select(DocumentParseRecord.knowledge_item_id)
+            .where(
+                DocumentParseRecord.knowledge_item_id.in_(all_ids),
+                DocumentParseRecord.status == ParseStatus.PARSED,
+            )
+        )
+        parsed_ids = set((await db.execute(parsed_ids_stmt)).scalars().all())
+        to_queue = [i for i in all_ids if i not in parsed_ids]
+    else:
+        to_queue = all_ids
+
+    if len(to_queue) > MAX_QUEUE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Too many items ({len(to_queue)}). Max {MAX_QUEUE} per call — pass item_ids to batch.",
+        )
+
+    for item_id in to_queue:
+        parse_document.delay(item_id)
+
+    return ReparseResponse(queued=len(to_queue), skipped=len(all_ids) - len(to_queue))

--- a/backend/app/routers/admin_reparse.py
+++ b/backend/app/routers/admin_reparse.py
@@ -5,19 +5,27 @@ pipeline so they get DocumentChunks (and downstream ES/Qdrant indexing).
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+import logging
+
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
+from slowapi.util import get_remote_address
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, DB
+from app.core.rate_limit import limiter
 from app.models.document import DocumentParseRecord, ParseStatus
 from app.models.knowledge import KnowledgeItem
+from app.models.sharing import AuditAction, AuditLog
 from app.models.user import UserRole
 from app.worker.tasks import parse_document
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
 MAX_QUEUE = 200
+_SKIP_STATUSES = {ParseStatus.PARSED, ParseStatus.PARSING}
 
 
 class ReparseRequest(BaseModel):
@@ -28,32 +36,40 @@ class ReparseRequest(BaseModel):
 class ReparseResponse(BaseModel):
     queued: int
     skipped: int
+    dispatch_failed: int = 0
 
 
 @router.post("/reparse", response_model=ReparseResponse, status_code=202)
-async def admin_reparse(body: ReparseRequest, db: DB, user: CurrentUser):
+@limiter.limit("10/minute", key_func=get_remote_address)
+async def admin_reparse(request: Request, body: ReparseRequest, db: DB, user: CurrentUser):
     """Re-queue historical files through the Tika parse pipeline."""
     if user.role != UserRole.ADMIN:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
 
     # Resolve candidate items.
-    if body.item_ids:
+    if body.item_ids is not None:
+        # Explicit list — even [] is honoured (0 items queued).
         stmt = select(KnowledgeItem.id).where(KnowledgeItem.id.in_(body.item_ids))
     else:
-        stmt = select(KnowledgeItem.id)
+        # No filter — cap at DB level to avoid full-table load.
+        stmt = select(KnowledgeItem.id).limit(MAX_QUEUE + 1)
+
     all_ids: list[int] = list((await db.execute(stmt)).scalars().all())
 
     if not body.force:
-        # Exclude items that already have status=PARSED.
-        parsed_ids_stmt = (
-            select(DocumentParseRecord.knowledge_item_id)
-            .where(
-                DocumentParseRecord.knowledge_item_id.in_(all_ids),
-                DocumentParseRecord.status == ParseStatus.PARSED,
+        # Exclude items that are PARSED or currently PARSING.
+        if all_ids:
+            skip_stmt = (
+                select(DocumentParseRecord.knowledge_item_id)
+                .where(
+                    DocumentParseRecord.knowledge_item_id.in_(all_ids),
+                    DocumentParseRecord.status.in_(_SKIP_STATUSES),
+                )
             )
-        )
-        parsed_ids = set((await db.execute(parsed_ids_stmt)).scalars().all())
-        to_queue = [i for i in all_ids if i not in parsed_ids]
+            skip_ids = set((await db.execute(skip_stmt)).scalars().all())
+        else:
+            skip_ids = set()
+        to_queue = [i for i in all_ids if i not in skip_ids]
     else:
         to_queue = all_ids
 
@@ -63,7 +79,34 @@ async def admin_reparse(body: ReparseRequest, db: DB, user: CurrentUser):
             detail=f"Too many items ({len(to_queue)}). Max {MAX_QUEUE} per call — pass item_ids to batch.",
         )
 
+    # Dispatch with partial-failure tolerance.
+    queued = 0
+    dispatch_failed = 0
     for item_id in to_queue:
-        parse_document.delay(item_id)
+        try:
+            parse_document.delay(item_id)
+            queued += 1
+        except Exception:
+            log.exception("Failed to dispatch parse for item %s", item_id)
+            dispatch_failed += 1
 
-    return ReparseResponse(queued=len(to_queue), skipped=len(all_ids) - len(to_queue))
+    # Audit trail.
+    db.add(AuditLog(
+        actor_id=user.id,
+        action=AuditAction.UPDATE,
+        resource_type="admin_reparse",
+        detail={
+            "queued": queued,
+            "skipped": len(all_ids) - len(to_queue),
+            "dispatch_failed": dispatch_failed,
+            "force": body.force,
+            "item_ids": body.item_ids,
+        },
+    ))
+    await db.commit()
+
+    return ReparseResponse(
+        queued=queued,
+        skipped=len(all_ids) - len(to_queue),
+        dispatch_failed=dispatch_failed,
+    )

--- a/backend/tests/test_admin_reparse.py
+++ b/backend/tests/test_admin_reparse.py
@@ -1,0 +1,30 @@
+"""Tests for POST /api/v1/admin/reparse."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.routers.admin_reparse import MAX_QUEUE, ReparseRequest, ReparseResponse
+
+
+def test_reparse_request_defaults():
+    r = ReparseRequest()
+    assert r.item_ids is None
+    assert r.force is False
+
+
+def test_reparse_request_with_ids():
+    r = ReparseRequest(item_ids=[1, 2, 3], force=True)
+    assert r.item_ids == [1, 2, 3]
+    assert r.force is True
+
+
+def test_reparse_response():
+    resp = ReparseResponse(queued=5, skipped=2)
+    assert resp.queued == 5
+    assert resp.skipped == 2
+
+
+def test_max_queue_value():
+    assert MAX_QUEUE == 200


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/admin/reparse` — Admin-only endpoint to re-queue historical KnowledgeItems through the Tika parse pipeline
- Items without DocumentChunks (legacy uploads before parse pipeline existed) get queued; downstream ES index + Qdrant vectorize chain automatically
- `item_ids` optional (defaults to all unparsed), `force` flag to bypass status check
- `MAX_QUEUE=200` per call to protect Celery from flood
- Returns `{queued, skipped}` immediately (202 Accepted)

Closes the gap where backfill script found 0 chunks / 0 vectors for legacy files.

## Test plan

- [ ] Call with no body → queues all unparsed items
- [ ] Call with `item_ids` → only queues specified items
- [ ] Call with `force: true` → re-queues even already-parsed items
- [ ] Call with >200 eligible items → returns 400 with batch guidance
- [ ] Non-admin user → 403
- [ ] Verify Celery tasks appear in worker logs
- [ ] After completion, confirm DocumentChunks exist and backfill script fills ES/Qdrant