### PR TITLE
fix: remove broken slowapi decorator from admin_reparse endpoint

### DIFF
--- a/backend/app/routers/admin_reparse.py
+++ b/backend/app/routers/admin_reparse.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
-from slowapi.util import get_remote_address
 from sqlalchemy import select
 
 from app.core.deps import CurrentUser, DB
-from app.core.rate_limit import limiter
 from app.models.document import DocumentParseRecord, ParseStatus
 from app.models.knowledge import KnowledgeItem
 from app.models.sharing import AuditAction, AuditLog
@@ -40,8 +38,7 @@ class ReparseResponse(BaseModel):
 
 
 @router.post("/reparse", response_model=ReparseResponse, status_code=202)
-@limiter.limit("10/minute", key_func=get_remote_address)
-async def admin_reparse(request: Request, body: ReparseRequest, db: DB, user: CurrentUser):
+async def admin_reparse(body: ReparseRequest, db: DB, user: CurrentUser):
     """Re-queue historical files through the Tika parse pipeline."""
     if user.role != UserRole.ADMIN:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")


### PR DESCRIPTION
## Bug

`POST /api/v1/admin/reparse` 返回 422，原因：

```
{"detail":[{"type":"missing","loc":["query","body"],...},{"loc":["query","db"],...},{"loc":["query","user"],...}]}
```

## 根因

`@limiter.limit("10/minute", key_func=get_remote_address)` 这种带 `key_func` 的 slowapi 装饰器形式没有正确保留函数签名，导致 FastAPI 把 `body`/`db`/`user` 全部误识别为 query params，而不是 request body + Depends 注入。

`agent.py` 里用 `@limiter.limit(AGENT_RATE)`（不带 key_func override）没有这个问题。

## 修复

移除该 `@limiter.limit` 装饰器。Admin 端点已有 role 保护（非 admin 返回 403），IP 级别限速是多余的。

## Test plan

- [ ] Merge 后部署
- [ ] `POST /api/v1/admin/reparse {"force": false}` 应返回 202 `{"queued": N, "skipped": M}`

🤖 Raven / WarrenStartup DevOps