### PR TITLE
infra: Celery worker + beat Fly.io config

### DIFF
--- a/backend/fly.worker.toml
+++ b/backend/fly.worker.toml
@@ -1,0 +1,35 @@
+# Celery worker — runs from the same Docker image as ekm-backend,
+# but overrides CMD to start Celery instead of Uvicorn.
+#
+# Deploy:
+#   fly deploy -c fly.worker.toml --remote-only
+#
+# Secrets: copy from ekm-backend (DATABASE_URL, REDIS_URL, LLM_API_KEY, etc.)
+#   fly secrets import -c fly.worker.toml < <(fly secrets list -a ekm-backend --json | jq -r '.[] | "\(.Name)=\(.Digest)"')
+#   — or manually: fly secrets set -a ekm-worker SECRET_KEY=... DATABASE_URL=...
+
+app = "ekm-worker"
+primary_region = "sin"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  APP_ENV = "staging"
+  DEBUG = "false"
+  LLM_MODEL = "anthropic/claude-sonnet-4.6"
+  LLM_BASE_URL = "https://ai-gateway.happycapy.ai/api/v1"
+  ELASTICSEARCH_URL = "http://ekm-es.internal:9200"
+  QDRANT_URL = "http://ekm-qdrant.internal:6333"
+  NEO4J_URL = "bolt://ekm-neo4j.internal:7687"
+  TIKA_URL = "http://ekm-tika.internal:9998"
+
+# Worker does not serve HTTP — no [[services]] section.
+
+[processes]
+  worker = "celery -A app.worker.celery_app worker --loglevel=info --concurrency=2"
+  beat = "celery -A app.worker.celery_app beat --loglevel=info"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"


### PR DESCRIPTION
## Summary

- Adds `backend/fly.worker.toml` — Fly.io config for `ekm-worker` app
- Same Docker image as `ekm-backend`, entrypoint overridden to Celery
- Two processes: `worker` (concurrency 2) + `beat` (scheduled tasks)
- No HTTP services — broker-only communication via Redis
- Env vars mirror `ekm-backend` for internal service URLs

## Context

Staging currently has **no Celery worker**. All async tasks (document parse, KG extraction, auto-archive tick, sharing purge) are enqueued to Redis but never consumed. This blocks every feature that depends on background processing.

## Deploy steps (Raven)

1. `fly apps create ekm-worker --org <org>`
2. Sync secrets from ekm-backend: `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, `LLM_API_KEY`, etc.
3. `cd backend && fly deploy -c fly.worker.toml --remote-only`
4. Verify: `fly logs -a ekm-worker` should show `celery@... ready`

## Test plan

- [ ] `fly deploy -c fly.worker.toml` succeeds
- [ ] `fly logs -a ekm-worker` shows both worker and beat processes
- [ ] Trigger a parse task (upload a doc) — worker picks it up
- [ ] Wait for 03:17/03:42 UTC — beat fires periodic tasks