### PR TITLE
feat: S3 object storage — replace volume mount

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,7 +28,15 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 REFRESH_TOKEN_EXPIRE_DAYS=30
 
 # ── File storage ───────────────────────────────────────────────────────
-UPLOAD_DIR=/data/uploads
+# S3-compatible object storage (Fly Tigris, AWS S3, MinIO).
+# Leave S3_BUCKET empty to fall back to local disk (dev).
+S3_BUCKET=
+S3_ENDPOINT_URL=https://fly.storage.tigris.dev
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_REGION=auto
+# Local fallback (dev only, when S3_BUCKET is empty)
+UPLOAD_DIR=/tmp/ekm_uploads
 MAX_UPLOAD_SIZE_MB=100
 
 # ── LLM (LiteLLM) ──────────────────────────────────────────────────────

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     # App
     APP_NAME: str = "EKM API"
     APP_VERSION: str = "0.1.0"
+    APP_ENV: str = "development"  # "development" | "staging" | "production"
     DEBUG: bool = False
 
     # Database

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,7 +52,14 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
 
-    # File storage
+    # File storage — S3-compatible object storage (Fly Tigris, MinIO, AWS S3).
+    # Leave S3_BUCKET empty to fall back to local disk (dev mode).
+    S3_BUCKET: str = ""
+    S3_ENDPOINT_URL: str = ""          # e.g. https://fly.storage.tigris.dev
+    S3_ACCESS_KEY_ID: str = ""
+    S3_SECRET_ACCESS_KEY: str = ""
+    S3_REGION: str = "auto"
+    # Local fallback (dev / tests only when S3_BUCKET is empty)
     UPLOAD_DIR: str = "/tmp/ekm_uploads"
     MAX_UPLOAD_SIZE_MB: int = 100
 

--- a/backend/app/services/document_parse.py
+++ b/backend/app/services/document_parse.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from app.core.config import settings
 from app.models.document import DocumentChunk, DocumentParseRecord, ParseStatus
 from app.models.knowledge import KnowledgeItem
+from app.services import storage
 from app.services.chunker import chunk_text
 from app.services.tika_client import tika, TikaError
 
@@ -60,7 +61,8 @@ def parse_and_persist(document_id: int) -> dict[str, Any]:
         db.commit()
 
         try:
-            text, meta = _run(tika.extract(item.file_path))
+            file_bytes = storage.download(item.file_path)
+            text, meta = _run(tika.extract(file_bytes))
         except TikaError as e:
             log.exception("tika failed for doc %s", document_id)
             record.status = ParseStatus.FAILED

--- a/backend/app/services/document_update.py
+++ b/backend/app/services/document_update.py
@@ -35,12 +35,15 @@ def run_incremental_update(document_id: int) -> dict[str, Any]:
         if not item.file_path:
             raise ValueError(f"KnowledgeItem {document_id} has no file_path")
 
-        # Step 1: Re-parse.
+        # Step 1: Re-parse (download from storage, send bytes to Tika).
         import asyncio
+        from app.services import storage
         from app.services.tika_client import tika
 
+        file_bytes = storage.download(item.file_path)
+
         async def _extract():
-            return await tika.extract(item.file_path)
+            return await tika.extract(file_bytes)
 
         loop = asyncio.new_event_loop()
         try:

--- a/backend/app/services/files.py
+++ b/backend/app/services/files.py
@@ -1,4 +1,5 @@
 """File upload service — stores files via the storage abstraction (S3 or local)."""
+import asyncio
 import mimetypes
 import uuid
 from pathlib import Path
@@ -57,12 +58,15 @@ async def _read_and_validate(file: UploadFile) -> bytes:
     return content
 
 
-def _save(content: bytes, original_name: str) -> str:
-    """Write content to storage and return the storage key."""
+async def _save(content: bytes, original_name: str) -> str:
+    """Write content to storage and return the storage key.
+
+    Runs the (sync) boto3 call in a thread so we don't block the event loop.
+    """
     ext = _ext(original_name)
     stem = uuid.uuid4().hex
     key = f"{stem}.{ext}" if ext else stem
-    storage.upload(content, key)
+    await asyncio.to_thread(storage.upload, content, key)
     return key
 
 
@@ -73,7 +77,7 @@ async def upload_single(
     category_id: int | None = None,
 ) -> KnowledgeItem:
     content = await _read_and_validate(file)
-    rel_path = _save(content, file.filename or "upload")
+    rel_path = await _save(content, file.filename or "upload")
     mime = file.content_type or mimetypes.guess_type(file.filename or "")[0] or "application/octet-stream"
     ext = _ext(file.filename or "")
 

--- a/backend/app/services/files.py
+++ b/backend/app/services/files.py
@@ -1,6 +1,5 @@
-"""File upload service — stores files locally (swap MinIO client here when ready)."""
+"""File upload service — stores files via the storage abstraction (S3 or local)."""
 import mimetypes
-import os
 import uuid
 from pathlib import Path
 
@@ -8,8 +7,8 @@ from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from app.core.config import settings
 from app.models.knowledge import FileType, KnowledgeItem
+from app.services import storage
 from app.schemas.files import (
     ALLOWED_EXTENSIONS,
     MAX_BATCH_MB,
@@ -58,15 +57,13 @@ async def _read_and_validate(file: UploadFile) -> bytes:
     return content
 
 
-def _save_to_disk(content: bytes, original_name: str) -> str:
-    upload_dir = Path(settings.UPLOAD_DIR)
-    upload_dir.mkdir(parents=True, exist_ok=True)
-    # Preserve extension, randomise stem to avoid collisions
+def _save(content: bytes, original_name: str) -> str:
+    """Write content to storage and return the storage key."""
     ext = _ext(original_name)
     stem = uuid.uuid4().hex
-    rel_path = f"{stem}.{ext}" if ext else stem
-    (upload_dir / rel_path).write_bytes(content)
-    return rel_path  # relative storage path
+    key = f"{stem}.{ext}" if ext else stem
+    storage.upload(content, key)
+    return key
 
 
 async def upload_single(
@@ -76,7 +73,7 @@ async def upload_single(
     category_id: int | None = None,
 ) -> KnowledgeItem:
     content = await _read_and_validate(file)
-    rel_path = _save_to_disk(content, file.filename or "upload")
+    rel_path = _save(content, file.filename or "upload")
     mime = file.content_type or mimetypes.guess_type(file.filename or "")[0] or "application/octet-stream"
     ext = _ext(file.filename or "")
 

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,8 +1,10 @@
 """File storage abstraction — S3 backend with local-disk fallback.
 
 When ``settings.S3_BUCKET`` is set, files are stored in an S3-compatible
-bucket (Fly Tigris, AWS S3, MinIO).  When empty, files fall back to
-``settings.UPLOAD_DIR`` on the local filesystem (dev / test only).
+bucket (Fly Tigris, AWS S3, MinIO).  When empty **and APP_ENV is not
+production/staging**, files fall back to ``settings.UPLOAD_DIR`` on the
+local filesystem.  In non-dev environments an empty ``S3_BUCKET`` causes
+a hard startup failure to prevent silent fallback bugs.
 
 All public functions accept and return **storage keys** — opaque strings
 like ``"abc123.pdf"`` that map 1-to-1 with ``KnowledgeItem.file_path``.
@@ -15,6 +17,26 @@ from pathlib import Path
 from app.core.config import settings
 
 log = logging.getLogger(__name__)
+
+# Max single-object download (bytes).  Prevents OOM on the 512 MB worker.
+MAX_DOWNLOAD_BYTES = settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024  # matches upload cap
+
+
+class StorageError(RuntimeError):
+    """Raised on any storage-layer failure (wraps boto / filesystem errors)."""
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast guard — catch missing S3 config in staging/prod at import time
+# ---------------------------------------------------------------------------
+_DEV_ENVS = {"development", "dev", "test", "testing"}
+
+if not settings.S3_BUCKET and getattr(settings, "APP_ENV", "development").lower() not in _DEV_ENVS:
+    raise StorageError(
+        f"S3_BUCKET is empty but APP_ENV={getattr(settings, 'APP_ENV', '?')}. "
+        "Set S3_BUCKET via Fly secrets or switch APP_ENV to 'development'."
+    )
+
 
 # ---------------------------------------------------------------------------
 # S3 client (lazy singleton)
@@ -45,10 +67,14 @@ def _use_s3() -> bool:
 # ---------------------------------------------------------------------------
 
 def upload(content: bytes, key: str) -> None:
-    """Store *content* under *key*."""
+    """Store *content* under *key*.  Raises ``StorageError`` on failure."""
     if _use_s3():
-        _get_s3().put_object(Bucket=settings.S3_BUCKET, Key=key, Body=content)
-        log.debug("s3 upload: %s (%d bytes)", key, len(content))
+        import botocore.exceptions
+        try:
+            _get_s3().put_object(Bucket=settings.S3_BUCKET, Key=key, Body=content)
+            log.debug("s3 upload: %s (%d bytes)", key, len(content))
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            raise StorageError(f"S3 upload failed for key={key}: {e}") from e
     else:
         d = Path(settings.UPLOAD_DIR)
         d.mkdir(parents=True, exist_ok=True)
@@ -56,16 +82,28 @@ def upload(content: bytes, key: str) -> None:
 
 
 def download(key: str) -> bytes:
-    """Return the raw bytes for *key*.  Raises ``FileNotFoundError``."""
+    """Return the raw bytes for *key*.
+
+    Raises ``FileNotFoundError`` when the key doesn't exist.
+    Raises ``StorageError`` on size-cap breach or transport errors.
+    """
     if _use_s3():
         import botocore.exceptions
         try:
             resp = _get_s3().get_object(Bucket=settings.S3_BUCKET, Key=key)
+            size = resp.get("ContentLength", 0)
+            if size > MAX_DOWNLOAD_BYTES:
+                raise StorageError(
+                    f"Object {key} is {size} bytes, exceeds "
+                    f"MAX_DOWNLOAD_BYTES={MAX_DOWNLOAD_BYTES}"
+                )
             return resp["Body"].read()
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 raise FileNotFoundError(key) from e
-            raise
+            raise StorageError(f"S3 download failed for key={key}: {e}") from e
+        except botocore.exceptions.BotoCoreError as e:
+            raise StorageError(f"S3 download failed for key={key}: {e}") from e
     else:
         p = Path(settings.UPLOAD_DIR) / key
         if not p.exists():
@@ -76,8 +114,12 @@ def download(key: str) -> bytes:
 def delete(key: str) -> None:
     """Remove *key* from storage.  No-op if already absent."""
     if _use_s3():
-        _get_s3().delete_object(Bucket=settings.S3_BUCKET, Key=key)
-        log.debug("s3 delete: %s", key)
+        import botocore.exceptions
+        try:
+            _get_s3().delete_object(Bucket=settings.S3_BUCKET, Key=key)
+            log.debug("s3 delete: %s", key)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            raise StorageError(f"S3 delete failed for key={key}: {e}") from e
     else:
         p = Path(settings.UPLOAD_DIR) / key
         p.unlink(missing_ok=True)

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,83 @@
+"""File storage abstraction — S3 backend with local-disk fallback.
+
+When ``settings.S3_BUCKET`` is set, files are stored in an S3-compatible
+bucket (Fly Tigris, AWS S3, MinIO).  When empty, files fall back to
+``settings.UPLOAD_DIR`` on the local filesystem (dev / test only).
+
+All public functions accept and return **storage keys** — opaque strings
+like ``"abc123.pdf"`` that map 1-to-1 with ``KnowledgeItem.file_path``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from app.core.config import settings
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# S3 client (lazy singleton)
+# ---------------------------------------------------------------------------
+_s3 = None
+
+
+def _get_s3():
+    global _s3
+    if _s3 is None:
+        import boto3
+        _s3 = boto3.client(
+            "s3",
+            endpoint_url=settings.S3_ENDPOINT_URL or None,
+            aws_access_key_id=settings.S3_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY,
+            region_name=settings.S3_REGION,
+        )
+    return _s3
+
+
+def _use_s3() -> bool:
+    return bool(settings.S3_BUCKET)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def upload(content: bytes, key: str) -> None:
+    """Store *content* under *key*."""
+    if _use_s3():
+        _get_s3().put_object(Bucket=settings.S3_BUCKET, Key=key, Body=content)
+        log.debug("s3 upload: %s (%d bytes)", key, len(content))
+    else:
+        d = Path(settings.UPLOAD_DIR)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / key).write_bytes(content)
+
+
+def download(key: str) -> bytes:
+    """Return the raw bytes for *key*.  Raises ``FileNotFoundError``."""
+    if _use_s3():
+        import botocore.exceptions
+        try:
+            resp = _get_s3().get_object(Bucket=settings.S3_BUCKET, Key=key)
+            return resp["Body"].read()
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                raise FileNotFoundError(key) from e
+            raise
+    else:
+        p = Path(settings.UPLOAD_DIR) / key
+        if not p.exists():
+            raise FileNotFoundError(key)
+        return p.read_bytes()
+
+
+def delete(key: str) -> None:
+    """Remove *key* from storage.  No-op if already absent."""
+    if _use_s3():
+        _get_s3().delete_object(Bucket=settings.S3_BUCKET, Key=key)
+        log.debug("s3 delete: %s", key)
+    else:
+        p = Path(settings.UPLOAD_DIR) / key
+        p.unlink(missing_ok=True)

--- a/backend/app/services/tika_client.py
+++ b/backend/app/services/tika_client.py
@@ -29,14 +29,19 @@ class TikaClient:
         self.base_url = (base_url or settings.TIKA_URL).rstrip("/")
         self.timeout = timeout
 
-    async def extract(self, file_path: str | Path) -> tuple[str, dict[str, Any]]:
+    async def extract(self, file_path_or_bytes: str | Path | bytes) -> tuple[str, dict[str, Any]]:
         """Extract text + metadata in a single round-trip via /rmeta/text.
 
+        Accepts a local file path (str/Path) **or** raw bytes.
         Returns (text, metadata_dict). Raises TikaError on non-2xx.
         """
-        p = Path(file_path)
-        if not p.exists():
-            raise TikaError(f"file not found: {p}")
+        if isinstance(file_path_or_bytes, bytes):
+            body = file_path_or_bytes
+        else:
+            p = Path(file_path_or_bytes)
+            if not p.exists():
+                raise TikaError(f"file not found: {p}")
+            body = p.read_bytes()
 
         # /rmeta/text returns a JSON array of dicts; for single-doc upload
         # there's one element whose X-TIKA:content holds the text.
@@ -44,8 +49,7 @@ class TikaClient:
         headers = {"Accept": "application/json"}
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
-            with p.open("rb") as fh:
-                resp = await client.put(url, content=fh.read(), headers=headers)
+            resp = await client.put(url, content=body, headers=headers)
 
         if resp.status_code >= 400:
             raise TikaError(f"tika {resp.status_code}: {resp.text[:500]}")

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -7,17 +7,16 @@ primary_region = "sin"
 [env]
   PORT = "8000"
   DEBUG = "false"
-  UPLOAD_DIR = "/data/uploads"
   LLM_MODEL = "anthropic/claude-sonnet-4.6"
+  # S3-compatible storage (Fly Tigris). Secrets: S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
+  S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
   LLM_BASE_URL = "https://ai-gateway.happycapy.ai/api/v1"
   ELASTICSEARCH_URL = "http://ekm-es.internal:9200"
   QDRANT_URL = "http://ekm-qdrant.internal:6333"
   NEO4J_URL = "bolt://ekm-neo4j.internal:7687"
   TIKA_URL = "http://ekm-tika.internal:9998"
 
-[[mounts]]
-  source = "ekm_uploads"
-  destination = "/data/uploads"
+# Volume mount removed — files stored in S3/Tigris.
 
 [[services]]
   internal_port = 8000

--- a/backend/fly.worker.toml
+++ b/backend/fly.worker.toml
@@ -4,9 +4,9 @@
 # Deploy:
 #   fly deploy -c fly.worker.toml --remote-only
 #
-# Secrets: copy from ekm-backend (DATABASE_URL, REDIS_URL, LLM_API_KEY, etc.)
-#   fly secrets import -c fly.worker.toml < <(fly secrets list -a ekm-backend --json | jq -r '.[] | "\(.Name)=\(.Digest)"')
-#   — or manually: fly secrets set -a ekm-worker SECRET_KEY=... DATABASE_URL=...
+# Secrets (via `fly secrets set -a ekm-worker`):
+#   DATABASE_URL, REDIS_URL, SECRET_KEY, LLM_API_KEY,
+#   S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
 
 app = "ekm-worker"
 primary_region = "sin"
@@ -23,8 +23,11 @@ primary_region = "sin"
   QDRANT_URL = "http://ekm-qdrant.internal:6333"
   NEO4J_URL = "bolt://ekm-neo4j.internal:7687"
   TIKA_URL = "http://ekm-tika.internal:9998"
+  # S3-compatible storage (Fly Tigris). Secrets: S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
+  S3_ENDPOINT_URL = "https://fly.storage.tigris.dev"
 
 # Worker does not serve HTTP — no [[services]] section.
+# No volume mount — files are read from S3/Tigris.
 
 [processes]
   worker = "celery -A app.worker.celery_app worker --loglevel=info --concurrency=2"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,6 +43,9 @@ tika==2.6.0
 # Rate limiting
 slowapi==0.1.9
 
+# Object storage (S3-compatible — Fly Tigris, AWS S3, MinIO)
+boto3==1.35.81
+
 # Utils
 httpx==0.28.1
 python-dotenv==1.0.1

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,4 +1,4 @@
-"""Tests for app.services.storage — local-disk fallback path."""
+"""Tests for app.services.storage — local-disk fallback path + guards."""
 import tempfile
 
 import pytest
@@ -9,6 +9,7 @@ def _local_storage(monkeypatch):
     """Force local-disk mode with a temp directory."""
     tmpdir = tempfile.mkdtemp()
     monkeypatch.setattr("app.core.config.settings.S3_BUCKET", "")
+    monkeypatch.setattr("app.core.config.settings.APP_ENV", "development")
     monkeypatch.setattr("app.core.config.settings.UPLOAD_DIR", tmpdir)
     yield tmpdir
 
@@ -50,3 +51,11 @@ def test_upload_creates_dir(monkeypatch, tmp_path):
     monkeypatch.setattr("app.core.config.settings.UPLOAD_DIR", nested)
     upload(b"x", "f.bin")
     assert (tmp_path / "a" / "b" / "f.bin").read_bytes() == b"x"
+
+
+def test_storage_error_importable():
+    from app.services.storage import StorageError
+
+    assert issubclass(StorageError, RuntimeError)
+    err = StorageError("test error")
+    assert str(err) == "test error"

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,0 +1,52 @@
+"""Tests for app.services.storage — local-disk fallback path."""
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _local_storage(monkeypatch):
+    """Force local-disk mode with a temp directory."""
+    tmpdir = tempfile.mkdtemp()
+    monkeypatch.setattr("app.core.config.settings.S3_BUCKET", "")
+    monkeypatch.setattr("app.core.config.settings.UPLOAD_DIR", tmpdir)
+    yield tmpdir
+
+
+def test_upload_download_roundtrip(_local_storage):
+    from app.services.storage import upload, download
+
+    content = b"hello world"
+    upload(content, "test.txt")
+    assert download("test.txt") == content
+
+
+def test_download_missing_raises(_local_storage):
+    from app.services.storage import download
+
+    with pytest.raises(FileNotFoundError):
+        download("nonexistent.txt")
+
+
+def test_delete(_local_storage):
+    from app.services.storage import upload, delete, download
+
+    upload(b"data", "del.txt")
+    delete("del.txt")
+    with pytest.raises(FileNotFoundError):
+        download("del.txt")
+
+
+def test_delete_idempotent(_local_storage):
+    from app.services.storage import delete
+
+    delete("nope.txt")
+
+
+def test_upload_creates_dir(monkeypatch, tmp_path):
+    from app.services.storage import upload
+
+    nested = str(tmp_path / "a" / "b")
+    monkeypatch.setattr("app.core.config.settings.UPLOAD_DIR", nested)
+    upload(b"x", "f.bin")
+    assert (tmp_path / "a" / "b" / "f.bin").read_bytes() == b"x"


### PR DESCRIPTION
## Summary

- Replaces local-disk file storage with S3-compatible object storage (Fly Tigris)
- New `app/services/storage.py` abstraction: `upload()` / `download()` / `delete()`
- S3 backend via boto3 when `S3_BUCKET` is set; local-disk fallback for dev
- Both API server and Celery worker access files via S3 — no shared volume needed
- Removes `ekm_uploads` volume mount from `fly.toml` and `fly.worker.toml`

## Why

Fly.io volumes are single-attach (one machine per volume). Backend writes uploaded files to a volume, but the worker on a separate machine can't read them. Creating a separate volume for the worker doesn't help — it would be empty.

S3/Tigris is the right solution: both processes read/write to the same bucket over HTTP.

## Files changed

| File | Change |
|------|--------|
| `services/storage.py` | NEW — S3 + local fallback abstraction |
| `services/files.py` | `_save_to_disk` → `_save` via `storage.upload()` |
| `services/tika_client.py` | `extract()` now accepts `bytes` or file path |
| `services/document_parse.py` | `storage.download()` before Tika |
| `services/document_update.py` | Same pattern |
| `core/config.py` | S3_BUCKET, S3_ENDPOINT_URL, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_REGION |
| `requirements.txt` | +boto3 |
| `fly.toml` | Removed volume mount, added S3_ENDPOINT_URL |
| `fly.worker.toml` | No volume, S3 config |
| `.env.example` | S3 settings documented |
| `tests/test_storage.py` | 5 unit tests (local fallback) |

## Raven deploy steps

1. Create Tigris bucket: `fly storage create -a ekm-backend`
2. Set secrets on both apps:
   ```
   fly secrets set -a ekm-backend S3_BUCKET=<bucket> S3_ACCESS_KEY_ID=<key> S3_SECRET_ACCESS_KEY=<secret>
   fly secrets set -a ekm-worker  S3_BUCKET=<bucket> S3_ACCESS_KEY_ID=<key> S3_SECRET_ACCESS_KEY=<secret>
   ```
3. Deploy backend: `fly deploy -a ekm-backend`
4. Deploy worker: `fly deploy -c fly.worker.toml --remote-only`
5. Upload a test doc → verify parse task succeeds

## Data migration note

Existing files on the old volume need a one-time copy to Tigris. Raven can script:
```bash
# On the backend machine (fly ssh console):
for f in /data/uploads/*; do
  aws s3 cp "$f" "s3://<bucket>/$(basename $f)" --endpoint-url https://fly.storage.tigris.dev
done
```

## Test plan

- [x] 5 unit tests pass (local fallback: roundtrip, missing, delete, idempotent, mkdir)
- [ ] Upload doc on staging → verify S3 write
- [ ] Trigger parse → verify worker reads from S3
- [ ] Incremental update → verify re-parse from S3