### PR TITLE
fix: #128 antd App wrapper for static message holder

### DIFF
--- a/frontend/src/app/(main)/archive/page.tsx
+++ b/frontend/src/app/(main)/archive/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useCallback, useEffect, useState } from 'react'
 import {
-  Table, Tag, Button, Modal, Form, Input, Space,
-  Tabs, Badge, Tooltip, message, Popconfirm, Timeline,
+  App, Table, Tag, Button, Modal, Form, Input, Space,
+  Tabs, Badge, Tooltip, Popconfirm, Timeline,
 } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import {
@@ -49,6 +49,7 @@ interface RestoreRequest {
 // ── Component ──────────────────────────────────────────────────────
 
 export default function ArchivePage() {
+  const { message } = App.useApp()
   const { t } = useTranslation()
 
   const FILE_TYPE_LABEL: Record<string, string> = {

--- a/frontend/src/app/(main)/assistant/page.tsx
+++ b/frontend/src/app/(main)/assistant/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button, Input, Tag, Tooltip, message as antdMessage } from 'antd'
+import { App, Button, Input, Tag, Tooltip } from 'antd'
 import {
   SendOutlined, ClearOutlined, RobotOutlined, UserOutlined,
   FileTextOutlined, LinkOutlined,
@@ -24,6 +24,7 @@ interface Message {
 const SOURCE_PANEL_W = 320
 
 export default function AssistantPage() {
+  const { message: antdMessage } = App.useApp()
   const { t } = useTranslation()
   const router = useRouter()
   const [messages, setMessages] = useState<Message[]>([])

--- a/frontend/src/app/(main)/community/new/page.tsx
+++ b/frontend/src/app/(main)/community/new/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button, Input, Select, Tag, message, Progress, Tooltip } from 'antd'
+import { App, Button, Input, Select, Tag, Progress, Tooltip } from 'antd'
 import {
   BoldOutlined, ItalicOutlined, CodeOutlined, OrderedListOutlined,
   UnorderedListOutlined, LinkOutlined, PaperClipOutlined, EyeOutlined,
@@ -55,6 +55,7 @@ const DRAFT_KEY = 'ekm_post_draft'
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export default function NewPostPage() {
+  const { message } = App.useApp()
   const router = useRouter()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 

--- a/frontend/src/app/(main)/developer/page.tsx
+++ b/frontend/src/app/(main)/developer/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useState } from 'react'
 import {
-  Button, Input, Select, Table, Tag, Tabs, Statistic, Card,
-  Space, Tooltip, Popconfirm, message, Badge, Switch,
+  App, Button, Input, Select, Table, Tag, Tabs, Statistic, Card,
+  Space, Tooltip, Popconfirm, Badge, Switch,
 } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import {
@@ -74,6 +74,7 @@ function statusColor(code: number) { return STATUS_COLOR[code] ?? 'default' }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 export default function DeveloperPage() {
+  const { message } = App.useApp()
   const [apiKeys, setApiKeys]   = useState<ApiKey[]>(MOCK_KEYS)
   const [logs, setLogs]         = useState<RequestLog[]>(MOCK_LOGS)
   const [activeTab, setActiveTab] = useState('console')

--- a/frontend/src/app/(main)/editor/page.tsx
+++ b/frontend/src/app/(main)/editor/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useRef } from 'react'
 import {
-  Button, Input, Tag, Divider, Spin, Tooltip, message,
+  App, Button, Input, Tag, Divider, Spin, Tooltip,
 } from 'antd'
 import {
   RobotOutlined, ThunderboltOutlined, EditOutlined,
@@ -86,6 +86,7 @@ function simulateAI(action: AIAction, context: string): Promise<string> {
 }
 
 export default function EditorPage() {
+  const { message } = App.useApp()
   const router = useRouter()
   const [doc, setDoc]           = useState(INITIAL_DOC)
   const [selected, setSelected] = useState('')

--- a/frontend/src/app/(main)/knowledge-graph/KGCanvas.tsx
+++ b/frontend/src/app/(main)/knowledge-graph/KGCanvas.tsx
@@ -19,8 +19,8 @@ import {
 import type { Node, Edge, Connection, NodeTypes } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import {
-  Button, Input, Drawer, Descriptions, Tag, Tooltip, Select,
-  Space, Popconfirm, message, Modal, Form,
+  App, Button, Input, Drawer, Descriptions, Tag, Tooltip, Select,
+  Space, Popconfirm, Modal, Form,
 } from 'antd'
 import {
   SearchOutlined, PlusOutlined, DeleteOutlined,
@@ -107,6 +107,7 @@ const INIT_EDGES: Edge[] = [
 ]
 
 function KGCanvasInner() {
+  const { message } = App.useApp()
   const { fitView } = useReactFlow()
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<EntityData>>(INIT_NODES as Node<EntityData>[])
   const [edges, setEdges, onEdgesChange] = useEdgesState(INIT_EDGES)

--- a/frontend/src/app/(main)/knowledge/history/page.tsx
+++ b/frontend/src/app/(main)/knowledge/history/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState } from 'react'
-import { Button, Tag, Tooltip, Popconfirm, message, Badge } from 'antd'
+import { App, Button, Tag, Tooltip, Popconfirm, Badge } from 'antd'
 import {
   ClockCircleOutlined, RollbackOutlined, StarOutlined,
   StarFilled, ArrowLeftOutlined, SwapOutlined,
@@ -157,6 +157,7 @@ const LINE_TEXT_STYLE: Record<string, string> = {
 }
 
 export default function VersionHistoryPage() {
+  const { message } = App.useApp()
   const router = useRouter()
   const [versions, setVersions] = useState<VersionRecord[]>(MOCK_VERSIONS)
   const [selectedLeft, setSelectedLeft]   = useState<VersionRecord>(MOCK_VERSIONS[1])

--- a/frontend/src/app/(main)/ontology/page.tsx
+++ b/frontend/src/app/(main)/ontology/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useState } from 'react'
 import {
-  Table, Tag, Button, Modal, Form, Input, Select, Space,
-  Tabs, Tooltip, Popconfirm, Tree, message, Badge,
+  App, Table, Tag, Button, Modal, Form, Input, Select, Space,
+  Tabs, Tooltip, Popconfirm, Tree, Badge,
 } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import type { DataNode } from 'antd/es/tree'
@@ -89,6 +89,7 @@ function buildTree(entities: EntityType[]): DataNode[] {
 }
 
 export default function OntologyPage() {
+  const { message } = App.useApp()
   const [entities, setEntities]   = useState<EntityType[]>(MOCK_ENTITIES)
   const [relations, setRelations] = useState<RelationType[]>(MOCK_RELATIONS)
   const [activeTab, setActiveTab] = useState('entity')

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState } from 'react'
-import { Avatar, Tag, Button, Tabs, Form, Input, Select, message, Badge, Drawer } from 'antd'
+import { App, Avatar, Tag, Button, Tabs, Form, Input, Select, Badge, Drawer } from 'antd'
 import {
   EditOutlined, FileTextOutlined, TeamOutlined,
   CheckOutlined, LikeOutlined, StarOutlined,
@@ -53,6 +53,7 @@ const NOTIF_ICON: Record<string, React.ReactNode> = {
 }
 
 export default function ProfilePage() {
+  const { message } = App.useApp()
   const { user } = useAuth()
   const [editing, setEditing]               = useState(false)
   const [msgOpen, setMsgOpen]               = useState(false)

--- a/frontend/src/app/(main)/search/page.tsx
+++ b/frontend/src/app/(main)/search/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useState, useCallback, useRef, useEffect } from 'react'
 import {
-  Input, Select, Space, Segmented, Empty, Spin, Tag, Tooltip,
-  AutoComplete, Skeleton, message,
+  App, Input, Select, Space, Segmented, Empty, Spin, Tag, Tooltip,
+  AutoComplete, Skeleton,
 } from 'antd'
 import {
   SearchOutlined, FilterOutlined, SortAscendingOutlined,
@@ -35,6 +35,7 @@ const DEFAULT_FILTERS: SearchFilters = {
 }
 
 export default function SearchPage() {
+  const { message } = App.useApp()
   const [query, setQuery]         = useState('')
   const [inputVal, setInputVal]   = useState('')
   const [filters, setFilters]     = useState<SearchFilters>(DEFAULT_FILTERS)

--- a/frontend/src/app/(main)/tags/page.tsx
+++ b/frontend/src/app/(main)/tags/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useMemo } from 'react'
 import {
-  Button, Input, Tag, Select, Popconfirm, message,
+  App, Button, Input, Tag, Select, Popconfirm,
   Modal, Form, ColorPicker, Tabs, Checkbox, Tooltip,
 } from 'antd'
 import {
@@ -172,6 +172,7 @@ function CategoryTree({
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function TagsPage() {
+  const { message } = App.useApp()
   const [categories, setCategories]       = useState<Category[]>(INIT_CATEGORIES)
   const [tags, setTags]                   = useState<TagItem[]>(INIT_TAGS)
   const [tagSearch, setTagSearch]         = useState('')

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Button, Form, Input, Divider, message } from 'antd'
+import { App, Button, Form, Input, Divider } from 'antd'
 import {
   UserOutlined, LockOutlined, ApartmentOutlined,
   ReadOutlined, TeamOutlined, BranchesOutlined,
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const router = useRouter()
   const { t } = useTranslation()
   const { setAuth } = useAuthStore()
+  const { message } = App.useApp()
   const [loading, setLoading] = useState(false)
   const [ssoLoading, setSsoLoading] = useState(false)
   const [form] = Form.useForm()

--- a/frontend/src/components/AntdLocaleProvider.tsx
+++ b/frontend/src/components/AntdLocaleProvider.tsx
@@ -4,7 +4,7 @@
  * Switches between enUS and zhCN as the user changes language.
  */
 import { ReactNode } from 'react'
-import { ConfigProvider } from 'antd'
+import { App, ConfigProvider } from 'antd'
 import enUS from 'antd/locale/en_US'
 import zhCN from 'antd/locale/zh_CN'
 import { useTranslation } from 'react-i18next'
@@ -16,7 +16,7 @@ export default function AntdLocaleProvider({ children }: { children: ReactNode }
 
   return (
     <ConfigProvider theme={antdTheme} locale={locale}>
-      {children}
+      <App>{children}</App>
     </ConfigProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Wrap children with antd `<App>` component in `AntdLocaleProvider`
- Fixes: antd v5 static `message.error()` / `notification` / `modal` need `<App>` wrapper in Next.js App Router to mount the notification holder correctly
- Without this, the login page catch block fires `message.error()` but the toast is invisible

## Test plan
- [ ] Login with wrong credentials — error toast should appear
- [ ] Verify other pages using `message.success()` still work