### PR TITLE
feat: #125 knowledge items list endpoint + frontend wiring

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.routers import kg as kg_router
 from app.routers import chunk_history as chunk_history_router
 from app.routers import kg_review as kg_review_router
 from app.routers import admin_reparse as admin_reparse_router
+from app.routers import knowledge as knowledge_router
 
 
 @asynccontextmanager
@@ -120,10 +121,7 @@ app.include_router(kg_router.router)
 app.include_router(chunk_history_router.router)
 app.include_router(kg_review_router.router)
 app.include_router(admin_reparse_router.router)
-
-# Placeholder stubs — will be filled in as each feature issue is implemented
-# app.include_router(users.router,      prefix="/api/v1/users",     tags=["users"])
-# app.include_router(knowledge.router,  prefix="/api/v1/knowledge", tags=["knowledge"])
+app.include_router(knowledge_router.router)
 
 
 @app.exception_handler(Exception)

--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -1,0 +1,86 @@
+"""Knowledge items API.
+
+Endpoints:
+  GET /api/v1/knowledge/items   paginated list of non-archived items
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
+
+from app.core.deps import CurrentUser, DB
+from app.models.knowledge import KnowledgeItem, TagAssignment, Tag
+
+router = APIRouter(prefix="/api/v1/knowledge", tags=["knowledge"])
+
+
+@router.get("/items")
+async def list_items(
+    user: CurrentUser,
+    db: DB,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    search: str | None = Query(None, max_length=200),
+    file_type: str | None = Query(None),
+):
+    """Paginated list of non-archived knowledge items.
+
+    All authenticated users can call this. Each user sees:
+    - Items they uploaded
+    - Items shared with them (via sharing_records)
+    - ADMIN / KM_OPS see all items
+    """
+    from app.models.user import UserRole
+
+    base = (
+        select(KnowledgeItem)
+        .where(KnowledgeItem.is_archived.is_(False))
+        .options(
+            selectinload(KnowledgeItem.uploader),
+            selectinload(KnowledgeItem.tag_assignments).selectinload(TagAssignment.tag),
+        )
+    )
+
+    # Visibility: admin/km_ops see everything; others see own uploads.
+    # Sharing-based visibility is a follow-up; for now, own + admin.
+    if user.role not in (UserRole.KM_OPS, UserRole.ADMIN):
+        base = base.where(KnowledgeItem.uploader_id == user.id)
+
+    if search:
+        base = base.where(KnowledgeItem.name.ilike(f"%{search}%"))
+
+    if file_type:
+        base = base.where(KnowledgeItem.file_type == file_type)
+
+    # Count
+    count_q = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_q)).scalar_one()
+
+    # Fetch page
+    rows = (
+        await db.execute(
+            base.order_by(KnowledgeItem.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+    ).scalars().all()
+
+    return {
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "items": [
+            {
+                "id": str(item.id),
+                "name": item.name,
+                "fileType": item.file_type.value if hasattr(item.file_type, "value") else str(item.file_type),
+                "size": item.size,
+                "uploadedAt": item.created_at.isoformat(),
+                "uploadedBy": item.uploader.display_name if item.uploader else "Unknown",
+                "tags": [ta.tag.name for ta in item.tag_assignments if ta.tag],
+                "downloads": item.download_count,
+            }
+            for item in rows
+        ],
+    }

--- a/frontend/src/lib/useKnowledgeList.ts
+++ b/frontend/src/lib/useKnowledgeList.ts
@@ -1,10 +1,12 @@
 import useSWR from 'swr'
-import { MOCK_KNOWLEDGE_LIST } from '@/lib/mockUpload'
+import api from '@/lib/api'
 import type { KnowledgeItem } from '@/types/upload'
 
-// Simulates an API call; replace with real fetch(url) in production
 async function fetchKnowledgeList(): Promise<KnowledgeItem[]> {
-  return MOCK_KNOWLEDGE_LIST
+  const res = await api.get('/api/v1/knowledge/items', {
+    params: { page_size: 100 },
+  })
+  return res.data.items
 }
 
 export function useKnowledgeList() {
@@ -12,14 +14,13 @@ export function useKnowledgeList() {
     'knowledge/list',
     fetchKnowledgeList,
     {
-      // Cache for 60 s; revalidate on focus only if data is stale
       dedupingInterval: 60_000,
       revalidateOnFocus: false,
     }
   )
 
   function removeItem(id: string) {
-    mutate((prev) => prev?.filter((i) => i.id !== id), { revalidate: false })
+    mutate((prev) => prev?.filter((i) => String(i.id) !== id), { revalidate: false })
   }
 
   /** Called after a new upload + parse finishes so the freshly indexed


### PR DESCRIPTION
## Summary
- New `GET /api/v1/knowledge/items` — paginated, non-archived items with search/filter
- Admin/KM_OPS see all; regular users see own uploads
- Frontend `useKnowledgeList` hook now calls real API instead of mock data

## Test plan
- [ ] Login as regular user — see only own uploaded files
- [ ] Login as admin — see all files
- [ ] Search by filename
- [ ] Filter by file type