### PR TITLE
feat: #126 manual archive endpoint + frontend button

### DIFF
--- a/backend/app/routers/archive.py
+++ b/backend/app/routers/archive.py
@@ -4,6 +4,8 @@ Endpoints:
   GET    /api/v1/archive/items             list archived knowledge items
                                             - regular user: own uploads only
                                             - km_ops/admin: all
+  POST   /api/v1/archive/request           manually archive an item
+                                            - owner or admin can archive
   GET    /api/v1/archive/rules             list rules (admin)
   POST   /api/v1/archive/rules             create
   GET    /api/v1/archive/rules/{id}        one
@@ -93,6 +95,50 @@ async def list_archived_items(
             }
             for item in rows
         ],
+    }
+
+
+# ── Manual archive request ────────────────────────────────────────
+
+class ArchiveRequestIn(BaseModel):
+    knowledge_item_id: int
+    reason: str | None = Field(default=None, max_length=2000)
+
+
+@router.post("/request", status_code=status.HTTP_200_OK)
+async def archive_item(
+    body: ArchiveRequestIn,
+    user: CurrentUser,
+    db: DB,
+):
+    """Manually archive a knowledge item.
+
+    Owner or admin can archive. Already-archived items are a no-op (200).
+    """
+    item = (await db.execute(
+        select(KnowledgeItem).where(KnowledgeItem.id == body.knowledge_item_id)
+    )).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="knowledge item not found",
+        )
+    # Permission: owner or admin
+    if item.uploader_id != user.id and user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="only item owner or admin can archive",
+        )
+    if not item.is_archived:
+        item.is_archived = True
+        item.archived_at = datetime.now(timezone.utc)
+        await db.flush()
+        await db.commit()
+    return {
+        "id": item.id,
+        "name": item.name,
+        "is_archived": item.is_archived,
+        "archived_at": item.archived_at.isoformat() if item.archived_at else None,
     }
 
 

--- a/frontend/src/app/(main)/knowledge/page.tsx
+++ b/frontend/src/app/(main)/knowledge/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Button, Input, Table, Tag, Tabs, Empty, Tooltip, Space, Popconfirm, Spin, Alert } from 'antd'
+import { Button, Input, Table, Tag, Tabs, Empty, Tooltip, Space, Popconfirm, Spin, Alert, message } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useTranslation } from 'react-i18next'
 import {
@@ -9,8 +9,9 @@ import {
   DeleteOutlined, EyeOutlined, TagOutlined, FireOutlined,
   FilePdfOutlined, FileWordOutlined, FileExcelOutlined, FilePptOutlined,
   FileZipOutlined, FileImageOutlined, FileTextOutlined, FileOutlined,
-  SoundOutlined, VideoCameraOutlined, HistoryOutlined,
+  SoundOutlined, VideoCameraOutlined, HistoryOutlined, InboxOutlined,
 } from '@ant-design/icons'
+import api from '@/lib/api'
 import UploadZone from '@/components/upload/UploadZone'
 import { formatFileSize } from '@/lib/mockUpload'
 import { useKnowledgeList } from '@/lib/useKnowledgeList'
@@ -91,6 +92,16 @@ export default function KnowledgePage() {
     // Reload the list so the newly indexed file appears; still keep the
     // panel open so the user can see the completed parse state.
     refresh()
+  }
+
+  async function handleArchive(id: string) {
+    try {
+      await api.post('/api/v1/archive/request', { knowledge_item_id: Number(id) })
+      message.success(t('knowledge.archived') ?? '已归档')
+      removeItem(id)
+    } catch {
+      message.error(t('common.error') ?? '操作失败')
+    }
   }
 
   function handleDelete(id: string) {
@@ -211,6 +222,20 @@ export default function KnowledgePage() {
               onClick={() => router.push(`/knowledge/history?id=${record.id}`)}
             />
           </Tooltip>
+          <Popconfirm
+            title={t('knowledge.archive_confirm') ?? '确认归档此文件？'}
+            onConfirm={() => handleArchive(record.id)}
+            okText={t('common.confirm') ?? '确认'}
+            cancelText={t('common.cancel')}
+          >
+            <Tooltip title={t('knowledge.archive_button') ?? '归档'}>
+              <Button
+                type="text" size="small"
+                icon={<InboxOutlined />}
+                className="text-slate-400 hover:text-orange-500"
+              />
+            </Tooltip>
+          </Popconfirm>
           <Popconfirm
             title={t('knowledge.delete_confirm')}
             description={t('knowledge.delete_confirm')}


### PR DESCRIPTION
## Summary
- New `POST /api/v1/archive/request` — owner or admin can manually archive an item
- Already-archived items are idempotent (200 no-op)
- Frontend: archive button added to knowledge list actions column with Popconfirm

## Test plan
- [ ] Click archive button on a file — confirm dialog appears
- [ ] Confirm archive — item disappears from list, success toast shown
- [ ] Verify item appears in /archive page after archiving
- [ ] Non-owner/non-admin gets 403