### PR TITLE
feat: #127 enrich RAG sources with document filename

### DIFF
--- a/backend/app/services/rag.py
+++ b/backend/app/services/rag.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 import asyncio
 from typing import AsyncIterator
 
+from sqlalchemy import select
+
 from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.models.knowledge import KnowledgeItem
 from app.services.embeddings import embedder
 from app.services.llm_client import llm
 from app.services.qdrant_client import search as qdrant_search
@@ -56,6 +60,18 @@ async def stream_answer(
     """
     k = top_k or settings.RAG_TOP_K
     hits = await asyncio.to_thread(_retrieve, query, k)
+
+    # Enrich hits with document filenames for the frontend sources panel.
+    if hits:
+        doc_ids = list({h["document_id"] for h in hits})
+        async with AsyncSessionLocal() as db:
+            rows = (await db.execute(
+                select(KnowledgeItem.id, KnowledgeItem.name)
+                .where(KnowledgeItem.id.in_(doc_ids))
+            )).all()
+        name_map = {row.id: row.name for row in rows}
+        for h in hits:
+            h["filename"] = name_map.get(h["document_id"])
 
     yield {"event": "sources", "data": hits}
 


### PR DESCRIPTION
## Summary
- After Qdrant retrieval, query KnowledgeItem.name for hit document IDs
- Sources SSE event now includes `filename` field
- Frontend sources panel can show real document names instead of fallback 'Document #42'

**Note**: The root cause of #127 (AI assistant not working) is likely missing \`LLM_API_KEY\` secret in staging. Raven should verify:
\`\`\`bash
fly secrets list -a ekm-backend | grep LLM
\`\`\`

## Test plan
- [ ] Ask a question in AI assistant — sources panel shows real filenames
- [ ] Verify no regression on RAG answer quality