### PR TITLE
fix: AI assistant chat stream — model prefix + error handling

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     TIKA_URL: str = "http://localhost:9998"
 
     # LLM (LiteLLM)
-    LLM_MODEL: str = "claude-sonnet-4-6"
+    LLM_MODEL: str = "openai/anthropic/claude-sonnet-4-6"
     LLM_BASE_URL: str = "https://ai-gateway.happycapy.ai/api/v1"
     LLM_API_KEY: str = ""
     LLM_MAX_TOKENS: int = 2048

--- a/backend/app/services/rag.py
+++ b/backend/app/services/rag.py
@@ -13,6 +13,7 @@ touching the router.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import AsyncIterator
 
 from sqlalchemy import select
@@ -23,6 +24,8 @@ from app.models.knowledge import KnowledgeItem
 from app.services.embeddings import embedder
 from app.services.llm_client import llm
 from app.services.qdrant_client import search as qdrant_search
+
+log = logging.getLogger(__name__)
 
 
 SYSTEM_PROMPT = (
@@ -86,8 +89,13 @@ async def stream_answer(
         },
     ]
 
-    async for delta in llm.stream(messages):
-        if delta:
-            yield {"event": "delta", "data": delta}
+    try:
+        async for delta in llm.stream(messages):
+            if delta:
+                yield {"event": "delta", "data": delta}
+    except Exception as exc:
+        log.exception("LLM stream failed: %s", exc)
+        yield {"event": "error", "data": f"LLM error: {type(exc).__name__}: {exc}"}
+        return
 
     yield {"event": "done", "data": "[DONE]"}

--- a/frontend/src/app/(main)/assistant/page.tsx
+++ b/frontend/src/app/(main)/assistant/page.tsx
@@ -80,6 +80,14 @@ export default function AssistantPage() {
           setMessages((prev) => prev.map((m) =>
             m.id === assistantId ? { ...m, content: m.content + evt.delta } : m,
           ))
+        } else if (evt.type === 'error') {
+          antdMessage.error(evt.message || '回答生成失败')
+          setMessages((prev) => prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, streaming: false, error: evt.message, content: m.content || '抱歉，回答生成失败。' }
+              : m,
+          ))
+          break
         } else if (evt.type === 'done') {
           setMessages((prev) => prev.map((m) =>
             m.id === assistantId ? { ...m, streaming: false } : m,

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -30,6 +30,7 @@ export type ChatEvent =
   | { type: 'sources'; sources: ChatSource[] }
   | { type: 'delta'; delta: string }
   | { type: 'done' }
+  | { type: 'error'; message: string }
 
 export interface StreamChatParams {
   query: string
@@ -69,6 +70,8 @@ function parseFrame(block: string): ChatEvent | null {
     }
     case 'done':
       return { type: 'done' }
+    case 'error':
+      return { type: 'error', message: data }
     default:
       return null
   }


### PR DESCRIPTION
## Summary
- **Root cause**: `LLM_MODEL` was `claude-sonnet-4-6` but AI Gateway uses OpenAI-compatible protocol. LiteLLM needs `openai/` prefix to route correctly → protocol mismatch caused silent LLM failures
- **Error handling**: SSE stream died silently on LLM error; frontend showed "回答生成失败" with no diagnostic info
- **Fix**: correct model name + try/except in rag.py yields `event: error` frame + frontend handles it with toast

## Changes
- `config.py`: `LLM_MODEL` default → `openai/anthropic/claude-sonnet-4-6`
- `rag.py`: LLM stream wrapped in try/except, yields `event: error` on failure
- `chatApi.ts`: added `error` event type to `ChatEvent` union
- `assistant/page.tsx`: handles `error` SSE event, shows toast + error UI state

## Test plan
- [ ] AI assistant answers questions (RAG end-to-end)
- [ ] Simulated LLM failure shows error toast instead of blank
- [ ] Sources panel still shows real filenames