### PR TITLE
fix: sanitize SSE error frame in rag.py

### DIFF
--- a/backend/app/services/rag.py
+++ b/backend/app/services/rag.py
@@ -95,7 +95,7 @@ async def stream_answer(
                 yield {"event": "delta", "data": delta}
     except Exception as exc:
         log.exception("LLM stream failed: %s", exc)
-        yield {"event": "error", "data": f"LLM error: {type(exc).__name__}: {exc}"}
+        yield {"event": "error", "data": "服务暂时不可用，请稍后重试"}
         return
 
     yield {"event": "done", "data": "[DONE]"}


### PR DESCRIPTION
## Summary
- Remove `type(exc).__name__: {exc}` from SSE error frame — LiteLLM exceptions may leak request_id and provider internals
- Replace with generic "服务暂时不可用，请稍后重试"
- Detailed error already captured by `log.exception()` server-side

Follows up on PR #133 per Sage P2 suggestion.

## Test plan
- [ ] Trigger LLM error (e.g. invalid API key) and verify browser only sees generic message
- [ ] Verify server logs still contain full exception details

🤖 Generated with [Claude Code](https://claude.com/claude-code)