### PR TITLE
fix: missing i18n keys + hardcoded Chinese fallbacks

### DIFF
--- a/frontend/src/app/(main)/assistant/page.tsx
+++ b/frontend/src/app/(main)/assistant/page.tsx
@@ -82,10 +82,10 @@ export default function AssistantPage() {
             m.id === assistantId ? { ...m, content: m.content + evt.delta } : m,
           ))
         } else if (evt.type === 'error') {
-          antdMessage.error(evt.message || '回答生成失败')
+          antdMessage.error(evt.message || t('assistant.error_message'))
           setMessages((prev) => prev.map((m) =>
             m.id === assistantId
-              ? { ...m, streaming: false, error: evt.message, content: m.content || '抱歉，回答生成失败。' }
+              ? { ...m, streaming: false, error: evt.message, content: m.content || t('assistant.error_message') }
               : m,
           ))
           break
@@ -100,15 +100,15 @@ export default function AssistantPage() {
         // User cancelled — mark the bubble as stopped without shouting.
         setMessages((prev) => prev.map((m) =>
           m.id === assistantId
-            ? { ...m, streaming: false, content: m.content || '（已取消）' }
+            ? { ...m, streaming: false, content: m.content || t('assistant.cancelled') }
             : m,
         ))
       } else {
-        const msg = err instanceof Error ? err.message : '请求失败'
+        const msg = err instanceof Error ? err.message : t('assistant.error_message')
         antdMessage.error(msg)
         setMessages((prev) => prev.map((m) =>
           m.id === assistantId
-            ? { ...m, streaming: false, error: msg, content: m.content || '抱歉，回答生成失败。' }
+            ? { ...m, streaming: false, error: msg, content: m.content || t('assistant.error_message') }
             : m,
         ))
       }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -100,7 +100,10 @@
     "type_archive": "Archive",
     "type_audio": "Audio",
     "type_video": "Video",
-    "type_other": "Other"
+    "type_other": "Other",
+    "archive_confirm": "Archive this file?",
+    "archive_button": "Archive",
+    "archived": "Archived"
   },
   "archive": {
     "page_title": "Archive Management",
@@ -148,7 +151,8 @@
     "empty_tip": "Ask a question to get started",
     "thinking": "Thinking...",
     "error_message": "Something went wrong, please try again",
-    "stop_button": "Stop"
+    "stop_button": "Stop",
+    "cancelled": "(Cancelled)"
   },
   "dashboard": {
     "greeting_morning": "Good morning",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -100,7 +100,10 @@
     "type_archive": "压缩包",
     "type_audio": "音频",
     "type_video": "视频",
-    "type_other": "其他"
+    "type_other": "其他",
+    "archive_confirm": "确认归档此文件？",
+    "archive_button": "归档",
+    "archived": "已归档"
   },
   "archive": {
     "page_title": "归档管理",
@@ -148,7 +151,8 @@
     "empty_tip": "输入问题开始对话",
     "thinking": "思考中...",
     "error_message": "出现错误，请重试",
-    "stop_button": "停止"
+    "stop_button": "停止",
+    "cancelled": "（已取消）"
   },
   "dashboard": {
     "greeting_morning": "早上好",


### PR DESCRIPTION
## Summary
- Add missing `knowledge.archive_confirm`, `knowledge.archive_button`, `knowledge.archived` keys to en.json/zh.json (Bug C: archive Popconfirm showed raw key)
- Add `assistant.cancelled` key to both locale files
- Replace hardcoded Chinese fallback strings in assistant error/cancel paths with `t()` calls

## Root cause analysis

**Bug A (Dashboard EN still Chinese)** and **Bug B (error event no UI feedback)**: NOT code issues. The Fly.io frontend deploy has failed for the last 2 PRs (#133, #134) due to VM lease conflict:
```
Failed to acquire lease for 91854d6db4e683: machine ID lease currently held by another token
```
The code on `main` is correct — Dashboard i18n and SSE error handling are both there. **Raven needs to release the stuck VM lease** (`flyctl machines lease release 91854d6db4e683 -a ekm-frontend`) or force-redeploy, then all three bugs resolve.

**Bug C (archive confirm raw key)**: Actual missing keys, fixed in this PR.

## Test plan
- [ ] After Fly frontend redeploy: switch to EN, verify Dashboard shows English
- [ ] After Fly frontend redeploy: trigger LLM error, verify error toast + loading stops
- [ ] Verify archive Popconfirm shows "确认归档此文件？" (ZH) / "Archive this file?" (EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)