### PR TITLE
fix: i18n community dept badges + ontology locale-aware display

### DIFF
--- a/frontend/src/app/(main)/community/page.tsx
+++ b/frontend/src/app/(main)/community/page.tsx
@@ -36,6 +36,7 @@ type SortKey = 'latest' | 'hot' | 'comments'
 
 function getInitials(name: string) { return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2) }
 const DEPT_COLOR: Record<string, string> = { 技术: 'blue', 产品: 'purple', 项目: 'cyan', 市场: 'orange', '': 'default' }
+const DEPT_I18N_KEY: Record<string, string> = { 技术: 'community.dept_tech', 产品: 'community.dept_product', 项目: 'community.dept_project', 市场: 'community.dept_marketing' }
 
 const ALL_TAGS = Array.from(new Set(MOCK_POSTS.flatMap((p) => p.tags)))
 
@@ -180,7 +181,7 @@ export default function CommunityPage() {
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-slate-700 leading-tight">{post.author}</p>
                   <div className="flex items-center gap-1.5 mt-0.5">
-                    <Tag color={DEPT_COLOR[post.department]} className="text-[10px] m-0 px-1">{post.department}</Tag>
+                    <Tag color={DEPT_COLOR[post.department]} className="text-[10px] m-0 px-1">{DEPT_I18N_KEY[post.department] ? t(DEPT_I18N_KEY[post.department]) : post.department}</Tag>
                     <span className="text-[10px] text-slate-400">
                       <ClockCircleOutlined className="mr-0.5" />{post.publishedAt}
                     </span>

--- a/frontend/src/app/(main)/ontology/page.tsx
+++ b/frontend/src/app/(main)/ontology/page.tsx
@@ -58,9 +58,10 @@ const MOCK_RELATIONS: RelationType[] = [
   { id: 'r6', name: 'partOf',       displayName: '属于',      domain: 'Project',  range: 'Organization', source: 'custom',     description: '项目属于组织', usageCount: 78  },
 ]
 
-function buildTree(entities: EntityType[], t: (key: string) => string): DataNode[] {
+function buildTree(entities: EntityType[], t: (key: string) => string, locale: string): DataNode[] {
   const map = new Map<string, DataNode & { children: DataNode[] }>()
   const roots: DataNode[] = []
+  const isEn = locale === 'en'
 
   entities.forEach((e) => {
     map.set(e.name, {
@@ -68,8 +69,8 @@ function buildTree(entities: EntityType[], t: (key: string) => string): DataNode
       title: (
         <span className="flex items-center gap-2">
           <span className="w-2 h-2 rounded-full inline-block" style={{ background: e.color }} />
-          <span className="text-sm text-slate-700">{e.displayName}</span>
-          <span className="text-xs text-slate-400">({e.name})</span>
+          <span className="text-sm text-slate-700">{isEn ? e.name : e.displayName}</span>
+          <span className="text-xs text-slate-400">({isEn ? e.displayName : e.name})</span>
           {e.source === 'custom' && <Tag color="purple" className="text-[10px] m-0 px-1">{t('ontology.source_custom')}</Tag>}
         </span>
       ),
@@ -91,7 +92,7 @@ function buildTree(entities: EntityType[], t: (key: string) => string): DataNode
 
 export default function OntologyPage() {
   const { message } = App.useApp()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [entities, setEntities]   = useState<EntityType[]>(MOCK_ENTITIES)
   const [relations, setRelations] = useState<RelationType[]>(MOCK_RELATIONS)
   const [activeTab, setActiveTab] = useState('entity')
@@ -167,8 +168,8 @@ export default function OntologyPage() {
         <div className="flex items-center gap-2">
           <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ background: r.color }} />
           <div>
-            <span className="text-sm font-medium text-slate-700">{r.displayName}</span>
-            <span className="text-xs text-slate-400 ml-2">{r.name}</span>
+            <span className="text-sm font-medium text-slate-700">{i18n.language === 'en' ? r.name : r.displayName}</span>
+            <span className="text-xs text-slate-400 ml-2">{i18n.language === 'en' ? r.displayName : r.name}</span>
           </div>
         </div>
       ),
@@ -257,8 +258,8 @@ export default function OntologyPage() {
       key: 'name',
       render: (_, r) => (
         <div>
-          <span className="text-sm font-medium text-slate-700">{r.displayName}</span>
-          <span className="text-xs text-slate-400 ml-2">{r.name}</span>
+          <span className="text-sm font-medium text-slate-700">{i18n.language === 'en' ? r.name : r.displayName}</span>
+          <span className="text-xs text-slate-400 ml-2">{i18n.language === 'en' ? r.displayName : r.name}</span>
         </div>
       ),
     },
@@ -337,7 +338,7 @@ export default function OntologyPage() {
     },
   ]
 
-  const treeData = buildTree(entities, t)
+  const treeData = buildTree(entities, t, i18n.language)
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -459,7 +460,7 @@ export default function OntologyPage() {
             <Select
               allowClear
               placeholder={t('ontology.select_parent')}
-              options={entities.map((e) => ({ label: `${e.displayName} (${e.name})`, value: e.name }))}
+              options={entities.map((e) => ({ label: i18n.language === 'en' ? `${e.name} (${e.displayName})` : `${e.displayName} (${e.name})`, value: e.name }))}
             />
           </Form.Item>
           <Form.Item name="description" label={t('ontology.col_description')}>
@@ -492,13 +493,13 @@ export default function OntologyPage() {
             <Form.Item name="domain" label={t('ontology.domain_label')} rules={[{ required: true }]}>
               <Select
                 placeholder={t('ontology.domain_placeholder')}
-                options={entities.map((e) => ({ label: `${e.displayName} (${e.name})`, value: e.name }))}
+                options={entities.map((e) => ({ label: i18n.language === 'en' ? `${e.name} (${e.displayName})` : `${e.displayName} (${e.name})`, value: e.name }))}
               />
             </Form.Item>
             <Form.Item name="range" label={t('ontology.range_label')} rules={[{ required: true }]}>
               <Select
                 placeholder={t('ontology.range_placeholder')}
-                options={entities.map((e) => ({ label: `${e.displayName} (${e.name})`, value: e.name }))}
+                options={entities.map((e) => ({ label: i18n.language === 'en' ? `${e.name} (${e.displayName})` : `${e.displayName} (${e.name})`, value: e.name }))}
               />
             </Form.Item>
           </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -345,7 +345,11 @@
       "title_required": "Please enter a title",
       "content_required": "Please enter content",
       "published": "Post published"
-    }
+    },
+    "dept_tech": "Tech",
+    "dept_product": "Product",
+    "dept_project": "Project",
+    "dept_marketing": "Marketing"
   },
   "profile": {
     "messages": "Messages",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -345,7 +345,11 @@
       "title_required": "请输入标题",
       "content_required": "请输入内容",
       "published": "帖子已发布"
-    }
+    },
+    "dept_tech": "技术",
+    "dept_product": "产品",
+    "dept_project": "项目",
+    "dept_marketing": "市场"
   },
   "profile": {
     "messages": "消息",


### PR DESCRIPTION
## Summary

Zoey reported two i18n issues after #137 merged:

- **Community dept badges**: Built-in department enum values (技术/产品/项目/市场) now translate to English (Tech/Product/Project/Marketing) in EN mode. User-defined tags stay as-is.
- **Ontology entity/relation display**: EN mode now shows English name first with Chinese in parentheses (e.g. "Thing (事物)"). ZH mode keeps current order. Applied to tree sidebar, table columns, and Select dropdowns.

### Changes
- `community/page.tsx`: added `DEPT_I18N_KEY` map, Tag renders translated label
- `ontology/page.tsx`: `buildTree` + table columns + Select options use `i18n.language` to swap name/displayName order
- `en.json` / `zh.json`: +4 `community.dept_*` keys (519 total, symmetric)

## Test plan

- [ ] Switch to EN — community posts show "Tech" / "Product" / "Project" / "Marketing" badges
- [ ] Switch to ZH — community posts show "技术" / "产品" / "项目" / "市场" badges
- [ ] Ontology tree sidebar: EN shows "Thing (事物)", ZH shows "事物 (Thing)"
- [ ] Ontology entity/relation table columns follow same locale-aware order
- [ ] Ontology modal Select dropdowns follow same locale-aware order