### PR TITLE
feat: internal API for collab editing persistence (#39)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,5 +44,10 @@ LLM_MODEL=claude-sonnet-4-6
 LLM_BASE_URL=https://ai-gateway.happycapy.ai/api/v1
 LLM_API_KEY=CHANGE_ME
 
+# ── Internal service key (ekm-collab → ekm-backend) ─────────────────
+# Used by Hocuspocus to call /api/v1/internal/* endpoints.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+INTERNAL_SERVICE_KEY=
+
 # ── CORS ───────────────────────────────────────────────────────────────
 CORS_ORIGINS=["http://localhost:3000"]

--- a/backend/alembic/versions/0015_add_content_to_knowledge_items.py
+++ b/backend/alembic/versions/0015_add_content_to_knowledge_items.py
@@ -1,0 +1,21 @@
+"""add content column to knowledge_items
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-04-23
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("knowledge_items", sa.Column("content", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("knowledge_items", "content")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -86,6 +86,10 @@ class Settings(BaseSettings):
     # KG quality — edges below this confidence are flagged needs_review=True.
     KG_LOW_CONFIDENCE_THRESHOLD: float = 0.5
 
+    # Service-to-service auth key for internal APIs (ekm-collab → ekm-backend).
+    # Set via Fly secret: INTERNAL_SERVICE_KEY=<random-hex>
+    INTERNAL_SERVICE_KEY: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from app.routers import chunk_history as chunk_history_router
 from app.routers import kg_review as kg_review_router
 from app.routers import admin_reparse as admin_reparse_router
 from app.routers import knowledge as knowledge_router
+from app.routers import internal as internal_router
 
 
 @asynccontextmanager
@@ -122,6 +123,7 @@ app.include_router(chunk_history_router.router)
 app.include_router(kg_review_router.router)
 app.include_router(admin_reparse_router.router)
 app.include_router(knowledge_router.router)
+app.include_router(internal_router.router)
 
 
 @app.exception_handler(Exception)

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -80,6 +80,9 @@ class KnowledgeItem(Base):
     name: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     file_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    # Rich-text content from the collaborative Tiptap editor (HTML).
+    # NULL for items that have only been uploaded (not yet edited).
+    content: Mapped[str | None] = mapped_column(Text, nullable=True)
     # values_callable is load-bearing: the `filetype` Postgres enum type was
     # created with lowercase values ("document", "image", …) in 0001, but
     # SQLAlchemy's default is to serialize Python enum *names* (uppercase

--- a/backend/app/routers/internal.py
+++ b/backend/app/routers/internal.py
@@ -1,0 +1,102 @@
+"""Internal service-to-service API.
+
+These endpoints are called by ekm-collab (Hocuspocus) and authenticated
+via a shared INTERNAL_SERVICE_KEY header — NOT user JWT.  They must never
+be exposed to end users; keep them behind an internal network or verify
+the header in every handler.
+"""
+
+from fastapi import APIRouter, Header, HTTPException, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.models.knowledge import KnowledgeItem
+from app.models.sharing import SharingRecord, SharePermission
+
+router = APIRouter(prefix="/api/v1/internal", tags=["internal"])
+
+
+def _verify_service_key(x_service_key: str = Header(...)) -> None:
+    """Reject requests without a valid service key."""
+    if not settings.INTERNAL_SERVICE_KEY:
+        raise HTTPException(status_code=503, detail="Internal API not configured")
+    if x_service_key != settings.INTERNAL_SERVICE_KEY:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
+# ---------- 1. Content persistence (Hocuspocus onStoreDocument) ----------
+
+class ContentUpdate(BaseModel):
+    content: str  # HTML from Tiptap
+
+
+@router.put("/items/{item_id}/content")
+async def update_item_content(
+    item_id: int,
+    body: ContentUpdate,
+    db: AsyncSession = Depends(get_db),
+    _auth: None = Depends(_verify_service_key),
+):
+    """Persist collaborative-editing content to the knowledge item.
+
+    Called by Hocuspocus server on document store.  Overwrites the
+    `content` column with the latest Tiptap HTML.
+    """
+    item = await db.get(KnowledgeItem, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    item.content = body.content
+    # get_db auto-commits on success
+    return {"ok": True}
+
+
+# ---------- 2. Room access check (Hocuspocus onAuthenticate) ----------
+
+@router.get("/items/{item_id}/access")
+async def check_item_access(
+    item_id: int,
+    user_id: int,
+    db: AsyncSession = Depends(get_db),
+    _auth: None = Depends(_verify_service_key),
+):
+    """Check whether *user_id* may access *item_id* for collaborative editing.
+
+    Returns 200 with ``{"allowed": true, "permission": "..."}`` if the user
+    is the owner, an admin/KM_OPS, or has a sharing record with EDIT
+    permission.  Returns 200 with ``{"allowed": false}`` otherwise (Raven's
+    onAuthenticate maps this to a WebSocket reject).
+    """
+    item = await db.get(KnowledgeItem, item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    # Owner always allowed
+    if item.uploader_id == user_id:
+        return {"allowed": True, "permission": "owner"}
+
+    # Admin / KM_OPS bypass (import here to avoid circular dep at module level)
+    from app.models.user import User, UserRole
+    user = await db.get(User, user_id)
+    if user and user.role in (UserRole.ADMIN, UserRole.KM_OPS):
+        return {"allowed": True, "permission": user.role.value}
+
+    # Check sharing records
+    stmt = (
+        select(SharingRecord)
+        .where(
+            SharingRecord.knowledge_item_id == item_id,
+            SharingRecord.shared_to_user_id == user_id,
+            SharingRecord.permission == SharePermission.EDIT,
+            SharingRecord.deleted_at.is_(None),
+        )
+    )
+    result = await db.execute(stmt)
+    share = result.scalar_one_or_none()
+    if share:
+        return {"allowed": True, "permission": "shared_edit"}
+
+    return {"allowed": False}


### PR DESCRIPTION
## Summary

Backend support for Hocuspocus server-side document persistence and room access control (Issue #39).

### New endpoints (X-Service-Key auth)

| Method | Path | Purpose |
|--------|------|---------|
| `PUT` | `/api/v1/internal/items/{item_id}/content` | Hocuspocus `onStoreDocument` — persist Tiptap HTML to DB |
| `GET` | `/api/v1/internal/items/{item_id}/access?user_id=N` | Hocuspocus `onAuthenticate` — check user's room access |

### Access check logic

1. Owner (`uploader_id == user_id`) — always allowed
2. Admin / KM_OPS role — always allowed
3. EDIT sharing record (active, not soft-deleted) — allowed
4. Otherwise — `{allowed: false}`

### Schema change

- Alembic `0015`: adds nullable `content` (TEXT) column to `knowledge_items`
- Stores the Tiptap rich-text HTML; NULL for items that haven't been collaboratively edited yet

### Config

- `INTERNAL_SERVICE_KEY`: shared secret between ekm-collab and ekm-backend
- Empty = internal endpoints return 503 (fail-safe, not fail-open)

### Coordination with Raven

Raven's ekm-collab `server.js` (already on main) calls these endpoints:
- `onStoreDocument` → `PUT /internal/items/{id}/content`
- `onAuthenticate` → `GET /internal/items/{id}/access?user_id=N`

After this PR merges + `fly secrets set INTERNAL_SERVICE_KEY=<value>`, Raven redeploys ekm-collab.

## Test plan

- [ ] `PUT /internal/items/1/content` with valid service key → 200
- [ ] `PUT /internal/items/1/content` with wrong key → 403
- [ ] `PUT /internal/items/1/content` without key → 422
- [ ] `PUT /internal/items/999/content` → 404
- [ ] `GET /internal/items/1/access?user_id=<owner>` → `{allowed: true, permission: "owner"}`
- [ ] `GET /internal/items/1/access?user_id=<admin>` → `{allowed: true, permission: "admin"}`
- [ ] `GET /internal/items/1/access?user_id=<shared_edit>` → `{allowed: true, permission: "shared_edit"}`
- [ ] `GET /internal/items/1/access?user_id=<stranger>` → `{allowed: false}`
- [ ] Alembic upgrade applies cleanly; content column exists and accepts TEXT