### PR TITLE
fix(agent): kg_stats Cypher SyntaxError — add WITH between UNWIND and WHERE

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -196,7 +196,7 @@ async def _exec_kg_stats(_args: dict) -> dict:
         )
         types = await graph.run(
             "MATCH (n:Entity) UNWIND labels(n) AS lbl "
-            "WHERE lbl <> 'Entity' "
+            "WITH n, lbl WHERE lbl <> 'Entity' "
             "RETURN lbl AS type, count(n) AS cnt ORDER BY cnt DESC LIMIT 20"
         )
         return {


### PR DESCRIPTION
## Problem

`kg_stats` tool in the Agent has been failing silently since deployment:

```
kg_stats failed: Neo.ClientError.Statement.SyntaxError
Invalid input 'WHERE': expected 'FOREACH', 'ORDER BY', 'CALL', ...
MATCH (n:Entity) UNWIND labels(n) AS lbl WHERE lbl <> 'Entity' RETURN ...
                                          ^
```

In Neo4j 5.x, `WHERE` cannot directly follow `UNWIND ... AS lbl`. A `WITH` clause is required as an intermediary step.

This caused:
1. Every `kg_stats` call to throw a `SyntaxError`, caught by the `except Exception` block
2. Tool returning `{"error": "无法获取知识图谱统计信息"}`
3. Agent always reporting it cannot retrieve knowledge graph statistics

Neo4j **does** have data — entities from docs 38, 39, 41 are correctly stored. The bug was purely in the query syntax.

## Fix

Add `WITH n, lbl` between `UNWIND` and `WHERE`:

```cypher
-- Before (invalid in Neo4j 5.x)
MATCH (n:Entity) UNWIND labels(n) AS lbl WHERE lbl <> 'Entity' RETURN ...

-- After
MATCH (n:Entity) UNWIND labels(n) AS lbl WITH n, lbl WHERE lbl <> 'Entity' RETURN ...
```

## Root Cause Analysis (full)

From the Fly.io production logs:
- Docs 1, 2, 35, 36: `status=PENDING` — predated worker deployment, pipeline never ran
- Docs 38, 39, 41: `status=DONE` — pipeline completed, entities confirmed in Neo4j
- `kg_stats` SyntaxError caused all stats queries to fail despite Neo4j being healthy

## Test Plan

- [ ] Deploy and ask agent "知识图谱里有多少个实体节点？"
- [ ] Verify `kg_stats` tool returns `node_count > 0` instead of error
- [ ] Run admin reparse on docs 1, 2, 35, 36, 37 to backfill their KG data

🤖 Generated with [Claude Code](https://claude.com/claude-code)