### PR TITLE
fix(editor): crash on SPA navigation — two-phase Collaboration init

### DIFF
--- a/frontend/src/components/editor/CollabEditor.tsx
+++ b/frontend/src/components/editor/CollabEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
@@ -51,30 +51,37 @@ export default function CollabEditor({
 }: CollabEditorProps) {
   const cursorColor = useMemo(() => hashColor(userName), [userName])
 
-  const ydocRef = useRef<Y.Doc | null>(null)
-  const providerRef = useRef<HocuspocusProvider | null>(null)
-  const [ready, setReady] = useState(false)
+  // ── Synchronous Y.Doc + Provider init ──────────────────────────────────────
+  // Create Y.Doc and HocuspocusProvider synchronously during the first render
+  // so that useEditor ALWAYS receives Collaboration extensions from the start.
+  // This avoids the two-phase editor creation (StarterKit-only → reconfigure
+  // with Collaboration) that crashes ProseMirror during SPA navigation.
+  const collabRef = useRef<{ ydoc: Y.Doc; provider: HocuspocusProvider; key: string } | null>(null)
+  const collabKey = `${roomName}::${collabUrl}::${token}`
 
-  // P1-1 fix: useEffect lifecycle — destroy + recreate on roomName/token change.
-  // useMemo would leak WebSocket connections when switching documents.
-  useEffect(() => {
+  if (!collabRef.current || collabRef.current.key !== collabKey) {
+    // Tear down previous connection when room/token changes
+    if (collabRef.current) {
+      collabRef.current.provider.destroy()
+      collabRef.current.ydoc.destroy()
+    }
     const ydoc = new Y.Doc()
     const provider = new HocuspocusProvider({
       url: collabUrl,
       name: roomName,
       document: ydoc,
-      // P1-2 fix: pass JWT token so Hocuspocus onAuthenticate can verify
       token,
       onStatus: ({ status }: { status: string }) => {
         onConnectionChange?.(status as ConnectionStatus)
       },
     })
+    collabRef.current = { ydoc, provider, key: collabKey }
+  }
 
-    ydocRef.current = ydoc
-    providerRef.current = provider
-    setReady(true)
+  const { ydoc, provider } = collabRef.current
 
-    // Track online users via awareness
+  // Track online users via awareness
+  useEffect(() => {
     const awareness = provider.awareness
     function updateUsers() {
       const states = awareness?.getStates()
@@ -95,31 +102,27 @@ export default function CollabEditor({
     }
     awareness?.on('change', updateUsers)
     updateUsers()
+    return () => { awareness?.off('change', updateUsers) }
+  }, [provider, onUsersChange])
 
+  // Cleanup on unmount
+  useEffect(() => {
     return () => {
-      awareness?.off('change', updateUsers)
-      provider.destroy()
-      ydoc.destroy()
-      ydocRef.current = null
-      providerRef.current = null
-      setReady(false)
+      collabRef.current?.provider.destroy()
+      collabRef.current?.ydoc.destroy()
+      collabRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [roomName, collabUrl, token])
+  }, [])
 
   const editor = useEditor(
     {
       extensions: [
-        StarterKit.configure({}),
-        ...(ydocRef.current
-          ? [
-              Collaboration.configure({ document: ydocRef.current }),
-              CollaborationCursor.configure({
-                provider: providerRef.current!,
-                user: { name: userName, color: cursorColor },
-              }),
-            ]
-          : []),
+        StarterKit.configure({ history: false }),
+        Collaboration.configure({ document: ydoc }),
+        CollaborationCursor.configure({
+          provider,
+          user: { name: userName, color: cursorColor },
+        }),
       ],
       editorProps: {
         attributes: {
@@ -129,7 +132,7 @@ export default function CollabEditor({
         },
       },
     },
-    [ready, userName, cursorColor],
+    [collabKey, userName, cursorColor],
   )
 
   return (


### PR DESCRIPTION
## 问题

从 Dashboard 点击「AI Writing」跳转到 `/editor` 时，页面崩溃显示 "This page couldn't load"。

直接访问 `/editor`（完整页面加载）正常，仅 SPA 客户端导航必现。

## 根因

`CollabEditor` 的 Y.Doc 和 HocuspocusProvider 在 `useEffect` 中创建（异步），导致 `useEditor` 经历两阶段初始化：

1. 首次渲染：`ydocRef.current = null` → 编辑器仅用 `StarterKit` 创建（无 Collaboration）
2. Effect 执行后：`ready = true` → `useEditor` deps 变化，调用 `refreshEditorInstance` 尝试用 Collaboration 重建
3. ProseMirror `reconfigure` 崩溃：`TypeError: Cannot read properties of undefined (reading 'doc')` — Collaboration 插件的 init 期望 Yjs 文档，但拿到的是不兼容的纯 ProseMirror state

完整页面加载时 `dynamic()` import 有延迟，时序恰好没触发；SPA 导航时 chunk 已缓存，组件同步挂载，两阶段创建立即触发崩溃。

## 修复

- Y.Doc + HocuspocusProvider 改用 `useRef` 惰性初始化（同步），首次渲染即携带 Collaboration，消除两阶段重建
- `StarterKit.configure({ history: false })` — 禁用与 Collaboration y-undo 冲突的内置 history
- 用 `roomName::collabUrl::token` 复合 key 检测连接参数变化，自动销毁重建
- 卸载时通过独立 `useEffect` 清理 WebSocket 连接

## 测试

1. 登录 → Dashboard → 点击「AI Writing」→ 编辑器正常加载（不再崩溃）
2. 直接访问 `/editor` → 仍然正常
3. 切换文档（改变 `?id=` 参数）→ WebSocket 正确断开重连