### PR TITLE
fix(editor): StarterKit v3 uses undoRedo, not history

### DIFF
--- a/frontend/src/components/editor/CollabEditor.tsx
+++ b/frontend/src/components/editor/CollabEditor.tsx
@@ -117,7 +117,7 @@ export default function CollabEditor({
   const editor = useEditor(
     {
       extensions: [
-        StarterKit.configure({ history: false }),
+        StarterKit.configure({ undoRedo: false }),
         Collaboration.configure({ document: ydoc }),
         CollaborationCursor.configure({
           provider,


### PR DESCRIPTION
## 问题

PR #163 合入后 CI/CD 失败：TypeScript 类型检查报错

```
'history' does not exist in type 'Partial<StarterKitOptions>'
```

## 原因

项目用的是 `@tiptap/starter-kit@^3.22.4`（TipTap v3）。v3 把 `history` 选项重命名为 `undoRedo`。PR #163 用了 v2 的 API 名。

## 修复

`StarterKit.configure({ history: false })` → `StarterKit.configure({ undoRedo: false })`

一行改动，纯类型修复。