### PR TITLE
fix(editor): synchronous collab init to prevent SPA navigation crash

### DIFF
--- a/frontend/src/components/editor/CollabEditor.tsx
+++ b/frontend/src/components/editor/CollabEditor.tsx
@@ -40,80 +40,37 @@ interface CollabEditorProps {
   placeholder?: string
 }
 
-export default function CollabEditor({
-  roomName,
+interface CollabResources {
+  key: string
+  provider: HocuspocusProvider
+  ydoc: Y.Doc
+}
+
+interface CollabEditorContentProps {
+  provider: HocuspocusProvider
+  ydoc: Y.Doc
+  userName: string
+  cursorColor: string
+  placeholder?: string
+}
+
+interface AwarenessUserState {
+  name?: string
+  color?: string
+}
+
+function destroyResources(resources: CollabResources) {
+  resources.provider.destroy()
+  resources.ydoc.destroy()
+}
+
+function CollabEditorContent({
+  provider,
+  ydoc,
   userName,
-  collabUrl,
-  token,
-  onUsersChange,
-  onConnectionChange,
+  cursorColor,
   placeholder,
-}: CollabEditorProps) {
-  const cursorColor = useMemo(() => hashColor(userName), [userName])
-
-  // ── Synchronous Y.Doc + Provider init ──────────────────────────────────────
-  // Create Y.Doc and HocuspocusProvider synchronously during the first render
-  // so that useEditor ALWAYS receives Collaboration extensions from the start.
-  // This avoids the two-phase editor creation (StarterKit-only → reconfigure
-  // with Collaboration) that crashes ProseMirror during SPA navigation.
-  const collabRef = useRef<{ ydoc: Y.Doc; provider: HocuspocusProvider; key: string } | null>(null)
-  const collabKey = `${roomName}::${collabUrl}::${token}`
-
-  if (!collabRef.current || collabRef.current.key !== collabKey) {
-    // Tear down previous connection when room/token changes
-    if (collabRef.current) {
-      collabRef.current.provider.destroy()
-      collabRef.current.ydoc.destroy()
-    }
-    const ydoc = new Y.Doc()
-    const provider = new HocuspocusProvider({
-      url: collabUrl,
-      name: roomName,
-      document: ydoc,
-      token,
-      onStatus: ({ status }: { status: string }) => {
-        onConnectionChange?.(status as ConnectionStatus)
-      },
-    })
-    collabRef.current = { ydoc, provider, key: collabKey }
-  }
-
-  const { ydoc, provider } = collabRef.current
-
-  // Track online users via awareness
-  useEffect(() => {
-    const awareness = provider.awareness
-    function updateUsers() {
-      const states = awareness?.getStates()
-      if (!states) return
-      const users: CollabUser[] = []
-      states.forEach((state) => {
-        if (state.user?.name) {
-          users.push({ name: state.user.name, color: state.user.color })
-        }
-      })
-      const seen = new Set<string>()
-      const unique = users.filter((u) => {
-        if (seen.has(u.name)) return false
-        seen.add(u.name)
-        return true
-      })
-      onUsersChange?.(unique)
-    }
-    awareness?.on('change', updateUsers)
-    updateUsers()
-    return () => { awareness?.off('change', updateUsers) }
-  }, [provider, onUsersChange])
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      collabRef.current?.provider.destroy()
-      collabRef.current?.ydoc.destroy()
-      collabRef.current = null
-    }
-  }, [])
-
+}: CollabEditorContentProps) {
   const editor = useEditor(
     {
       extensions: [
@@ -132,12 +89,112 @@ export default function CollabEditor({
         },
       },
     },
-    [collabKey, userName, cursorColor],
+    [provider, ydoc, userName, cursorColor, placeholder],
   )
+
+  return <EditorContent editor={editor} className="h-full" />
+}
+
+export default function CollabEditor({
+  roomName,
+  userName,
+  collabUrl,
+  token,
+  onUsersChange,
+  onConnectionChange,
+  placeholder,
+}: CollabEditorProps) {
+  const cursorColor = useMemo(() => hashColor(userName), [userName])
+  const connectionKey = `${roomName}::${collabUrl}::${token}`
+  const resourcesRef = useRef<CollabResources | null>(null)
+  const onConnectionChangeRef = useRef(onConnectionChange)
+  const onUsersChangeRef = useRef(onUsersChange)
+
+  onConnectionChangeRef.current = onConnectionChange
+  onUsersChangeRef.current = onUsersChange
+
+  let resources = resourcesRef.current
+
+  if (!resources || resources.key !== connectionKey) {
+    if (resources) {
+      destroyResources(resources)
+    }
+
+    const ydoc = new Y.Doc()
+    const provider = new HocuspocusProvider({
+      url: collabUrl,
+      name: roomName,
+      document: ydoc,
+      token,
+      onStatus: ({ status }: { status: string }) => {
+        onConnectionChangeRef.current?.(status as ConnectionStatus)
+      },
+    })
+
+    resources = {
+      key: connectionKey,
+      provider,
+      ydoc,
+    }
+
+    resourcesRef.current = resources
+  }
+
+  useEffect(() => {
+    return () => {
+      if (resourcesRef.current) {
+        destroyResources(resourcesRef.current)
+        resourcesRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const awareness = resources.provider.awareness
+
+    function updateUsers() {
+      const states = awareness?.getStates()
+      if (!states) return
+
+      const users: CollabUser[] = []
+      states.forEach((state) => {
+        const user = (state as { user?: AwarenessUserState }).user
+        if (typeof user?.name === 'string') {
+          users.push({
+            name: user.name,
+            color: typeof user.color === 'string' ? user.color : hashColor(user.name),
+          })
+        }
+      })
+
+      const seen = new Set<string>()
+      const unique = users.filter((user) => {
+        if (seen.has(user.name)) return false
+        seen.add(user.name)
+        return true
+      })
+
+      onUsersChangeRef.current?.(unique)
+    }
+
+    awareness?.on('change', updateUsers)
+    updateUsers()
+
+    return () => {
+      awareness?.off('change', updateUsers)
+    }
+  }, [resources])
 
   return (
     <div className="flex-1 overflow-y-auto bg-white collab-editor">
-      <EditorContent editor={editor} className="h-full" />
+      <CollabEditorContent
+        key={connectionKey}
+        provider={resources.provider}
+        ydoc={resources.ydoc}
+        userName={userName}
+        cursorColor={cursorColor}
+        placeholder={placeholder}
+      />
       <style jsx global>{`
         .collab-editor .ProseMirror {
           min-height: 100%;


### PR DESCRIPTION
## 问题

从 Dashboard 点击「AI Writing」跳转 `/editor` 时崩溃 "This page couldn't load"。直接访问正常，仅 SPA 客户端导航必现。

此前 PR #163 + #164 修了部分问题但 CI 构建失败或运行时仍崩溃。

## 根因

`CollabEditor` 的 Y.Doc 在 `useEffect`（异步）中创建，导致 `useEditor` 两阶段初始化：
1. 首次渲染：只有 StarterKit（无 Collaboration）
2. Effect 后 reconfigure → ProseMirror 崩溃：`TypeError: Cannot read properties of undefined (reading 'doc')`

## 修复方案（Codex 实现）

- 拆出 `CollabEditorContent` 子组件，接收 `ydoc` + `provider` 作为 props，`useEditor` 始终带 Collaboration
- Y.Doc + HocuspocusProvider 改为 `useRef` 惰性同步初始化
- 用 React `key={connectionKey}` 控制挂载，room/token 变化时完整卸载重建（彻底避免 ProseMirror reconfigure）
- `StarterKit.configure({ undoRedo: false })`（TipTap v3 API）
- callback ref 避免 stale closure
- 独立 `useEffect` 处理 unmount 清理

## TypeScript 验证

`CollabEditor.tsx` 无类型错误（已验证 `tsc --noEmit`）。