### PR TITLE
fix(editor): replace CollaborationCursor with y-tiptap cursor plugin

### DIFF
--- a/frontend/src/components/editor/CollabEditor.tsx
+++ b/frontend/src/components/editor/CollabEditor.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useEffect, useMemo, useRef } from 'react'
-import { useEditor, EditorContent } from '@tiptap/react'
+import { useEditor, EditorContent, Extension } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
-import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
+import { yCursorPlugin, defaultSelectionBuilder } from '@tiptap/y-tiptap'
 import { HocuspocusProvider } from '@hocuspocus/provider'
 import * as Y from 'yjs'
 
@@ -64,6 +64,35 @@ function destroyResources(resources: CollabResources) {
   resources.ydoc.destroy()
 }
 
+function makeCursorExtension(
+  provider: HocuspocusProvider,
+  user: { name: string; color: string },
+) {
+  return Extension.create({
+    name: 'collaborationCursor',
+    addProseMirrorPlugins() {
+      const awareness = provider.awareness!
+      awareness.setLocalStateField('user', user)
+      return [
+        yCursorPlugin(awareness, {
+          cursorBuilder: (u: { name?: string; color?: string }) => {
+            const cursor = document.createElement('span')
+            cursor.classList.add('collaboration-cursor__caret')
+            cursor.setAttribute('style', `border-color: ${u.color}`)
+            const label = document.createElement('div')
+            label.classList.add('collaboration-cursor__label')
+            label.setAttribute('style', `background-color: ${u.color}`)
+            label.insertBefore(document.createTextNode(u.name ?? ''), null)
+            cursor.insertBefore(label, null)
+            return cursor
+          },
+          selectionBuilder: defaultSelectionBuilder,
+        }),
+      ]
+    },
+  })
+}
+
 function CollabEditorContent({
   provider,
   ydoc,
@@ -71,15 +100,17 @@ function CollabEditorContent({
   cursorColor,
   placeholder,
 }: CollabEditorContentProps) {
+  const cursorExt = useMemo(
+    () => makeCursorExtension(provider, { name: userName, color: cursorColor }),
+    [provider, userName, cursorColor],
+  )
+
   const editor = useEditor(
     {
       extensions: [
         StarterKit.configure({ undoRedo: false }),
         Collaboration.configure({ document: ydoc }),
-        CollaborationCursor.configure({
-          provider,
-          user: { name: userName, color: cursorColor },
-        }),
+        cursorExt,
       ],
       editorProps: {
         attributes: {


### PR DESCRIPTION
## Root Cause

`@tiptap/extension-collaboration@3.22.4` internally uses `@tiptap/y-tiptap`'s `ySyncPlugin`, while `@tiptap/extension-collaboration-cursor@3.0.0` imports `yCursorPlugin` from `y-prosemirror`. These two packages expose **different `ySyncPluginKey` instances**, so when the cursor plugin's `init()` looks up the sync plugin state, it gets `undefined` and crashes with:

```
TypeError: Cannot read properties of undefined (reading 'doc')
```

This is why all previous fixes (#162, #163, #164, #165) targeting the two-phase editor init didn't resolve the crash — the real bug was a dependency version mismatch at the ProseMirror plugin layer.

## Fix

Replace `CollaborationCursor` import with a custom TipTap extension that uses `@tiptap/y-tiptap`'s `yCursorPlugin` directly — the same package that `Collaboration@3.22.4` uses internally. This ensures both sync and cursor plugins share the same `ySyncPluginKey`.

## Changes

- `CollabEditor.tsx`: Remove `@tiptap/extension-collaboration-cursor` import, add `yCursorPlugin` + `defaultSelectionBuilder` from `@tiptap/y-tiptap`, create cursor extension inline via `makeCursorExtension()`

## Test Plan

- [ ] SPA navigation from Dashboard → AI Writing no longer crashes
- [ ] Direct URL navigation to /editor still works
- [ ] Collaboration cursors visible between multiple users
- [ ] CI build passes