### PR TITLE
fix(agent): remove from __future__ import annotations — resolves /openapi.json 500

### DIFF
--- a/backend/app/routers/agent.py
+++ b/backend/app/routers/agent.py
@@ -23,8 +23,6 @@ Design notes:
   500 where possible — Tom's Agent should see a partial or empty result
   instead of an outage. Unexpected errors still bubble.
 """
-from __future__ import annotations
-
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status


### PR DESCRIPTION
## Root Cause

`agent.py` had `from __future__ import annotations` on line 26. This causes all type annotations in the file to be treated as strings/ForwardRefs at runtime. When FastAPI builds the OpenAPI schema, Pydantic's `TypeAdapter` tries to resolve `KGQueryRequest` from the `kg_query` endpoint body annotation — but gets an unresolvable ForwardRef → HTTP 500.

`schemas/agent.py` already has a comment explicitly warning against this:
```
NOTE: Do NOT add `from __future__ import annotations` to this file.
```
The same constraint applies to any router that imports from it.

## Fix

Remove `from __future__ import annotations` from `app/routers/agent.py` — 1 line deleted, no logic changes.

## Test Plan
- [ ] `GET /openapi.json` returns 200 with full schema
- [ ] `GET /docs` loads Swagger UI correctly
- [ ] All `/api/agent/*` endpoints still function normally

Closes #167