### PR TITLE
fix: #168 document parse status stuck PENDING — add parse-status endpoint + task_track_started

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -1,10 +1,12 @@
 """Document processing endpoints.
 
-- POST /api/v1/documents/{id}/parse — enqueue Tika parse + fan-out
-- GET  /api/v1/documents/{id}/chunks — peek at parsed chunks (debugging UI)
+- POST /api/v1/documents/{id}/parse       — enqueue Tika parse + fan-out
+- GET  /api/v1/documents/{id}/parse-status — poll parse progress from DB (issue #168)
+- GET  /api/v1/documents/{id}/chunks      — peek at parsed chunks (debugging UI)
 
 The actual parsing runs in a Celery worker; this endpoint just returns a
-task_id that the UI polls via /api/v1/tasks/{task_id}.
+task_id that the UI polls via /api/v1/tasks/{task_id}, or more reliably
+via /api/v1/documents/{id}/parse-status which reads the DB directly.
 """
 from __future__ import annotations
 
@@ -37,7 +39,11 @@ async def trigger_parse(document_id: int, db: DB, user: CurrentUser):
         select(DocumentParseRecord).where(DocumentParseRecord.knowledge_item_id == document_id)
     )).scalar_one_or_none()
     if rec and rec.status == ParseStatus.PARSING:
-        return {"task_id": rec.task_id, "status": "already_parsing"}
+        return {
+            "task_id": rec.task_id,
+            "status": "already_parsing",
+            "parse_status_url": f"/api/v1/documents/{document_id}/parse-status",
+        }
 
     async_result = parse_document.delay(document_id)
 
@@ -54,7 +60,11 @@ async def trigger_parse(document_id: int, db: DB, user: CurrentUser):
         rec.error = None
     await db.commit()
 
-    return {"task_id": async_result.id, "status": "queued"}
+    return {
+        "task_id": async_result.id,
+        "status": "queued",
+        "parse_status_url": f"/api/v1/documents/{document_id}/parse-status",
+    }
 
 
 @router.get("/{document_id}/kg-status")
@@ -88,6 +98,31 @@ async def get_kg_status(document_id: int, db: DB, user: CurrentUser):
         "task_id": item.kg_task_id,
         "started_at": item.kg_started_at.isoformat() if item.kg_started_at else None,
         "completed_at": item.kg_completed_at.isoformat() if item.kg_completed_at else None,
+    }
+
+
+@router.get("/{document_id}/parse-status")
+async def get_parse_status(document_id: int, db: DB, user: CurrentUser):
+    """Return parse pipeline status for a document, read directly from DB.
+
+    Prefer this over polling /api/v1/tasks/{task_id} — Celery result backend
+    stays PENDING during task execution (unless task_track_started=True), but
+    DocumentParseRecord transitions to PARSING immediately when the worker
+    starts, so this endpoint gives accurate real-time status.
+
+    Returns 404 if parse has never been triggered for this document.
+    """
+    rec = (await db.execute(
+        select(DocumentParseRecord).where(DocumentParseRecord.knowledge_item_id == document_id)
+    )).scalar_one_or_none()
+    if rec is None:
+        raise HTTPException(status_code=404, detail="no parse record for this document")
+
+    return {
+        "document_id": document_id,
+        "status": rec.status.value,
+        "task_id": rec.task_id,
+        "error": rec.error,
     }
 
 

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -112,6 +112,14 @@ async def get_parse_status(document_id: int, db: DB, user: CurrentUser):
 
     Returns 404 if parse has never been triggered for this document.
     """
+    item = (await db.execute(
+        select(KnowledgeItem).where(KnowledgeItem.id == document_id)
+    )).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(status_code=404, detail="document not found")
+    if item.uploader_id != user.id and user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=403, detail="forbidden")
+
     rec = (await db.execute(
         select(DocumentParseRecord).where(DocumentParseRecord.knowledge_item_id == document_id)
     )).scalar_one_or_none()

--- a/backend/app/services/document_parse.py
+++ b/backend/app/services/document_parse.py
@@ -63,40 +63,47 @@ def parse_and_persist(document_id: int) -> dict[str, Any]:
         try:
             file_bytes = storage.download(item.file_path)
             text, meta = _run(tika.extract(file_bytes))
-        except TikaError as e:
-            log.exception("tika failed for doc %s", document_id)
-            record.status = ParseStatus.FAILED
-            record.error = str(e)
+
+            chunks = chunk_text(text)
+            log.info("parsed doc=%s chars=%d chunks=%d", document_id, len(text), len(chunks))
+
+            # Replace any prior chunks — parse is idempotent on re-run.
+            db.execute(delete(DocumentChunk).where(DocumentChunk.knowledge_item_id == document_id))
+            db.flush()
+
+            from app.services.chunk_updater import content_hash
+
+            rows = [
+                DocumentChunk(
+                    knowledge_item_id=document_id,
+                    chunk_index=c.index,
+                    content=c.content,
+                    token_count=c.char_count,  # char-count proxy; replaced in #22
+                    content_hash=content_hash(c.content),
+                )
+                for c in chunks
+            ]
+            db.add_all(rows)
+            db.flush()
+            chunk_ids = [r.id for r in rows]
+
+            record.status = ParseStatus.PARSED
+            record.error = None
+            record.metadata_json = json.dumps(_trim_meta(meta), ensure_ascii=False)
             db.commit()
+        except Exception as e:
+            # Catch-all: any failure after PARSING is set must mark the record
+            # FAILED so that /parse-status reflects the real terminal state.
+            # Without this, non-TikaError exceptions leave the DB stuck at PARSING
+            # while Celery result backend already shows FAILURE (issue #168).
+            log.exception("parse pipeline failed for doc %s", document_id)
+            try:
+                record.status = ParseStatus.FAILED
+                record.error = f"{type(e).__name__}: {e}"
+                db.commit()
+            except Exception:
+                log.exception("failed to persist FAILED status for doc %s", document_id)
             raise
-
-        chunks = chunk_text(text)
-        log.info("parsed doc=%s chars=%d chunks=%d", document_id, len(text), len(chunks))
-
-        # Replace any prior chunks — parse is idempotent on re-run.
-        db.execute(delete(DocumentChunk).where(DocumentChunk.knowledge_item_id == document_id))
-        db.flush()
-
-        from app.services.chunk_updater import content_hash
-
-        rows = [
-            DocumentChunk(
-                knowledge_item_id=document_id,
-                chunk_index=c.index,
-                content=c.content,
-                token_count=c.char_count,  # char-count proxy; replaced in #22
-                content_hash=content_hash(c.content),
-            )
-            for c in chunks
-        ]
-        db.add_all(rows)
-        db.flush()
-        chunk_ids = [r.id for r in rows]
-
-        record.status = ParseStatus.PARSED
-        record.error = None
-        record.metadata_json = json.dumps(_trim_meta(meta), ensure_ascii=False)
-        db.commit()
 
         return {
             "document_id": document_id,

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -46,6 +46,11 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,
     task_acks_late=True,
 
+    # Write STARTED to result backend when a worker picks up a task.
+    # Without this, result backend stays PENDING during execution, making
+    # it impossible to distinguish "queued" from "running" (issue #168).
+    task_track_started=True,
+
     # Periodic jobs — requires running `celery beat` alongside the worker:
     #     celery -A app.worker.celery_app beat --loglevel=info
     # See docker-compose.yml `beat` service (profile: worker).


### PR DESCRIPTION
## 问题

`POST /documents/{id}/parse` 触发解析后，客户端轮询 `GET /tasks/{task_id}` 长时间返回 `PENDING`，无法区分"排队等待"和"正在执行"。

## 根因（三个叠加）

1. **`task_track_started=False`（Celery 默认）**：result backend 在任务执行期间不写 STARTED，整个 ~37s 执行窗口内查询都返回 PENDING
2. **DB 状态未对外暴露**：`DocumentParseRecord` 在 worker 开始时立即变为 PARSING，但没有接口暴露这个信息
3. **Fly.io 冷启动叠加**：worker machine 从 stopped → starting 需要 5-15s，加上任务执行时间，客户端以为卡死

## 修复（方案 C）

### 1. `celery_app.py`
添加 `task_track_started=True`：worker 取到任务时立即向 result backend 写入 STARTED 状态。

### 2. `documents.py` — 新接口
```
GET /api/v1/documents/{id}/parse-status
```
直接读 DB（`DocumentParseRecord`），worker 开始处理时立即反映 PARSING，不依赖 Celery result backend 的 TTL 和延迟。

```json
{"document_id": 42, "status": "PARSING", "task_id": "d1925c5c-...", "error": null}
```

### 3. `documents.py` — trigger_parse 响应增加 `parse_status_url`
```json
{"task_id": "...", "status": "queued", "parse_status_url": "/api/v1/documents/42/parse-status"}
```
引导前端使用正确的轮询接口。

## 影响范围
- `GET /tasks/{task_id}` 不变（其他任务类型仍可用）
- `document_parse.py` / `tasks.py` 不变
- 仅修改两个文件，45 行变更

Closes #168